### PR TITLE
Tweak scoping

### DIFF
--- a/luchador/nn/core/tensorflow/scope.py
+++ b/luchador/nn/core/tensorflow/scope.py
@@ -9,20 +9,69 @@ from tensorflow import (
     get_variable_scope,
 )
 
+from luchador import get_nn_dtype
 from .wrapper import Variable
 from .initializer import TFInitializer
 
 __all__ = ['name_scope', 'get_variable', 'variable_scope',
            'VariableScope', 'get_variable_scope']
 
+###############################################################################
+# Mechanism for enabling reusing variable without explicitly giving dtype or
+# shape. When creating Variable with get_variable and reuse=False, we store
+# mapping from name to (dtype, shape). When retrieving the same Variable with
+# get_variable and reuse=True, we use the stored dtype corresponding the given
+# name and shape.
 
-def get_variable(name, shape=None, dtype=tf.float32,
+_DTYPES = {}
+
+
+def _register(name, shape, dtype):
+    _DTYPES[name] = {'dtype': dtype, 'shape': shape}
+
+
+def _retrieve(name):
+    info = _DTYPES[name]
+    return info['dtype'], info['shape']
+###############################################################################
+
+
+def get_variable(name, shape=None, dtype=None,
                  initializer=None, regularizer=None, trainable=True, **kwargs):
+    """Create Variable with the given configuration or retrieve existing one
+
+    This function works mostly same as tf.get_variable, except when retrieving
+    existing Variable, you only need name and need not to give shape and dtype.
+
+    Mapping from name to shape and dtype is internally cached so that you can
+    retrieve variable with only name.
+
+    Args:
+      name(str): Name of Variable to create or retrieve
+
+      shape(list): Used to create new Variable.
+                   Ignored when retrieving one
+
+      dtype(tf.Dtype compatible): Used to create new Variable.
+                                  Ignored when retrieving one
+
+      initializer(TFInitializer or tf.Initializer): Initializer object
+
+      For other arguments, see
+      https://www.tensorflow.org/versions/master/api_docs/python/state_ops.html#get_variable
+    """
     if isinstance(initializer, TFInitializer):
         initializer = initializer.get()
+
+    if tf.get_variable_scope().reuse:
+        dtype, shape = _retrieve(name)
+    else:
+        dtype = dtype or get_nn_dtype()
 
     variable = _get_variable(
         name, shape=shape, dtype=dtype, initializer=initializer,
         regularizer=regularizer, trainable=trainable, **kwargs)
 
-    return Variable(variable)
+    ret = Variable(variable)
+    _register(name, ret.shape, ret.dtype)
+    return ret

--- a/luchador/nn/core/theano/scope.py
+++ b/luchador/nn/core/theano/scope.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
 import logging
+import warnings
 
+import numpy as np
 import theano
 from theano import config
 
@@ -102,12 +104,13 @@ def get_variable_scope():
     return VariableScope(_get_flag(), _get_scope())
 
 
-def get_variable(name, shape=None, dtype=config.floatX,
+def get_variable(name, shape=None, dtype=None,
                  initializer=None, regularizer=None, trainable=None, **kwargs):
     if trainable:
-        raise NotImplementedError('trainable option is not yet implemented.')
+        warnings.warn('`trainable` is not implemented in Theano backend.')
+
     if regularizer:
-        raise NotImplementedError('regularizer option is not yet implemented.')
+        warnings.warn('`regularizer` is not implemented in Theano backend.')
 
     # 1. Check the current variable scope
     scope = _get_scope()
@@ -130,6 +133,9 @@ def get_variable(name, shape=None, dtype=config.floatX,
             raise ValueError(
                 'Shape of a new variable ({}) must be fully defined, '
                 'but instead was {}.'.format(name, shape))
+
+        dtype = dtype or config.floatX
+
         if not initializer:
             initializer = Normal(dtype=dtype)
 
@@ -139,7 +145,7 @@ def get_variable(name, shape=None, dtype=config.floatX,
 
         _VARIABLES[name] = Variable(
             theano.shared(
-                value=initializer.sample(shape),
+                value=np.array(initializer.sample(shape), dtype=dtype),
                 name=name, allow_downcast=True, **kwargs)
         )
 


### PR DESCRIPTION
This PR adds internal mechanism to Variable of Tensorflow backend to store `dtype` and `shape` information based on the `name` of the created variable.

Also this fixes `dtype` treatment at Theano Variable creation.
