### PR TITLE
Refactor backend

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -277,7 +277,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=numpy,theano,tensorflow
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/luchador/nn/core/base/cost.py
+++ b/luchador/nn/core/base/cost.py
@@ -1,3 +1,5 @@
+"""Define common interface for Cost classes"""
+
 from __future__ import absolute_import
 
 import logging
@@ -6,7 +8,7 @@ from luchador.common import get_subclasses, StoreMixin
 
 __all__ = [
     'BaseCost', 'get_cost',
-    'BaseSSE2',
+    'BaseSSE2', 'BaseSigmoidCrossEntropy',
 ]
 
 _LG = logging.getLogger(__name__)
@@ -17,26 +19,42 @@ class BaseCost(StoreMixin, object):
 
     Actual Cost class must implement `build` method.
     """
-    def __init__(self, elementwise=False, **args):
-        """Validate args and set it as instance property. See CopyMixin"""
+    def __init__(self, **args):
+        """Validate args and set it as instance property
+
+        See Also
+        --------
+        luchador.common.StoreMixin
+            Underlying mechanism to store constructor arguments
+        """
         super(BaseCost, self).__init__()
-        self._store_args(elementwise=elementwise, **args)
+        self._store_args(**args)
 
     def __call__(self, target, prediction):
-        """Build cost between target and prediction
-
-        Args:
-          target (Tensor): Correct value.
-          prediction (Tensor): The current prediction value.
-
-        Returns:
-          Tensor: Resulting cost value
-        """
+        """Convenience method to call `build`"""
         return self.build(target, prediction)
 
     def build(self, target, prediction):
+        """Build cost between target and prediction
+
+        Parameters
+        ----------
+        target : Tensor
+            Tensor holding value for correct prediction
+
+        prediction : Tensor
+            Tensor holding the current prediction value.
+
+        Returns
+        -------
+        Tensor
+            Tensor holding the cost between the given input tensors.
+        """
+        return self._build(target, prediction)
+
+    def _build(self, target, prediction):
         raise NotImplementedError(
-            '`build` method is not implemented for {}.{}.'
+            '`_build` method is not implemented for {}.{}.'
             .format(type(self).__module__, type(self).__name__)
         )
 
@@ -50,10 +68,36 @@ def get_cost(name):
 
 ###############################################################################
 class BaseSSE2(BaseCost):
-    """Sum-Squared Error
+    """Compute Sum-Squared-Error / 2.0 for the given target and prediction
 
-    Actual Cost class must implement `build` method.
+    TODO: Add math expression
+
+    Parameters
+    ----------
+    max_delta, min_delta : float
+        Clip the difference between target value and prediction values
+
+    elementwise : Bool
+        When true, the cost tesnor returned by `build` method has the same
+        shape as its input Tensors. When False, the cost tensor is flattened
+        to scalar shape by taking average over batch and sum over feature.
+        Default: False
     """
     def __init__(self, max_delta=None, min_delta=None, elementwise=False):
         super(BaseSSE2, self).__init__(
             max_delta=max_delta, min_delta=min_delta, elementwise=elementwise)
+
+
+class BaseSigmoidCrossEntropy(BaseCost):
+    """Directory computes classification entropy from logit
+
+    Parameters
+    ----------
+    elementwise : Bool
+        When true, the cost tesnor returned by `build` method has the same
+        shape as its input Tensors. When False, the cost tensor is flattened
+        to scalar shape by taking average over batch and sum over feature.
+        Defalut False
+    """
+    def __init__(self, elementwise=False):
+        super(BaseSigmoidCrossEntropy, self).__init__(elementwise=elementwise)

--- a/luchador/nn/core/base/layer.py
+++ b/luchador/nn/core/base/layer.py
@@ -150,14 +150,14 @@ class BaseConv2D(BaseLayer):
               - 'NHWC' (default): (batch, height, width, channel)
               - 'NCHW': (batch, channel, height, width)
 
-        padding:
+        padding :
             - [tensorflow] (str): Either 'SAME' or 'VALID'
             - [theano] (str or int or tuple of two int): See Theano doc
 
         with_bias : bool
             When True bias term is added after convolution
 
-        kwargs:
+        kwargs :
             Tensorflow: Arguments passed to tf.nn.conv2d. 'use_cudnn_on_gpu'
         """
         super(BaseConv2D, self).__init__(
@@ -168,16 +168,19 @@ class BaseConv2D(BaseLayer):
 
 ###############################################################################
 class BaseReLU(BaseLayer):
+    """Apply rectified linear activation"""
     def __init__(self):
         super(BaseReLU, self).__init__()
 
 
 class BaseSigmoid(BaseLayer):
+    """Apply Sigmoid activation elementwise"""
     def __init__(self):
         super(BaseSigmoid, self).__init__()
 
 
 class BaseSoftmax(BaseLayer):
+    """Apply Softmax activation"""
     def __init__(self):
         super(BaseSoftmax, self).__init__()
 

--- a/luchador/nn/core/base/layer.py
+++ b/luchador/nn/core/base/layer.py
@@ -11,8 +11,10 @@ _LG = logging.getLogger(__name__)
 __all__ = [
     'BaseLayer', 'get_layer',
     'BaseDense', 'BaseConv2D',
-    'BaseTrueDiv',
+    'BaseReLU', 'BaseSigmoid', 'BaseSoftmax',
+    'BaseTrueDiv', 'BaseFlatten',
     'BaseBatchNormalization',
+    'BaseNCHW2NHWC', 'BaseNHWC2NCHW',
 ]
 
 
@@ -38,7 +40,7 @@ class BaseLayer(SerializeMixin, object):
     def _add_update(self, name, op):
         self.update_operations[name] = op
 
-    def get_update_operations(self):
+    def get_update_operation(self):
         raise NotImplementedError(
             '`get_update_operation` method is not implemented for {}'
             .format(self.__class__)
@@ -60,6 +62,9 @@ class BaseLayer(SerializeMixin, object):
 
     def build(self, input_tensor):
         """Build layer computation graph on top of the given tensor"""
+        return self._build(input_tensor)
+
+    def _build(self, input_tensor):
         raise NotImplementedError(
             '`build` method is not implemented for {}'.format(self.__class__)
         )
@@ -74,52 +79,86 @@ def get_layer(name):
 
 ###############################################################################
 class BaseDense(BaseLayer):
+    """Apply 2D affine transformation.
+
+    Apply affine transformation to 2D tensor. Activation functions, such as
+    ReLU are not applied.
+
+    Input shape
+    -----------
+    (batch size, #input features)
+
+    Output shape
+    ------------
+    (batch size, #output features)
+
+    """
     def __init__(self, n_nodes, initializers=None, with_bias=True):
         """Initialize dense layer.
-        Also called fully connected, affine, linear or inner product.
 
-        Activation function, such as ReLU is not included.
+        Parameters
+        ----------
+        n_nodes : int
+            The number of internal neurons.
 
-        Args:
-          n_nodes (int): The number of internal neurons.
-          initializers (dict): Dictionary containing configuration.
-          with_bias (bool): When True bias term is added after multiplication
+        initializers : dict or None
+            Dictionary containing configuration.
+
+        with_bias : bool
+            When True, bias term is added after multiplication.
         """
         super(BaseDense, self).__init__(
             n_nodes=n_nodes, initializers=initializers, with_bias=with_bias)
 
 
 class BaseConv2D(BaseLayer):
+    """Apply 2D convolution.
+
+    Apply convolution to 4D tensor
+
+    Input shape
+    -----------
+    HCHW format
+        (batch size, #input channel, #input height, #input width) when data
+
+    NHWC format (Tensorflow backend only)
+        (batch size, #input height, #input width, #input channel)
+    """
     def __init__(self, filter_height, filter_width, n_filters, strides,
                  padding='VALID', initializers=None, with_bias=True, **kwargs):
         """Initialize 2D convolution layer.
-        Args:
-          filter_height (int): filter height (== row)
 
-          filter_weight (int): filter weight (== column)
+        Parameters
+        ----------
+        filter_height : int
+            filter height, (#rows in filter)
 
-          n_filters (int): #filters (== #output channels)
+        filter_weight : int
+            filter weight (#columns in filter)
 
-          strides (int, tuple of two int, or tuple of four int): stride
+        n_filters : int
+            #filters (#output channels)
+
+        strides : (int, tuple of two int, or tuple of four int)
             - When given type is int, the output is subsampled by this factor
               in both width and height direction.
             - When given type is tuple of two int, the output is subsapmled
               `strides[0]` in height direction and `striders[1]` in width
               direction.
-            - [Tensorflow only] When given type is tuple of four int, it must
+            - In Tensorflow, when given type is tuple of four int, it must
               be consistent with the input data format. That is:
-              - data_format=='NHWC' (default): [batch, height, width, channel]
-              - data_format=='NCHW': [batch, channel, height, width]
+              - 'NHWC' (default): (batch, height, width, channel)
+              - 'NCHW': (batch, channel, height, width)
 
-          padding:
+        padding:
             - [tensorflow] (str): Either 'SAME' or 'VALID'
             - [theano] (str or int or tuple of two int): See Theano doc
 
-          with_bias (bool): When True bias term is added after convolution
+        with_bias : bool
+            When True bias term is added after convolution
 
-          kwargs:
-            - Tensorflow: Arguments passed to tf.nn.conv2d.
-              'use_cudnn_on_gpu' and 'name'
+        kwargs:
+            Tensorflow: Arguments passed to tf.nn.conv2d. 'use_cudnn_on_gpu'
         """
         super(BaseConv2D, self).__init__(
             filter_height=filter_height, filter_width=filter_width,
@@ -127,22 +166,73 @@ class BaseConv2D(BaseLayer):
             initializers=initializers, with_bias=with_bias, **kwargs)
 
 
+###############################################################################
+class BaseReLU(BaseLayer):
+    def __init__(self):
+        super(BaseReLU, self).__init__()
+
+
+class BaseSigmoid(BaseLayer):
+    def __init__(self):
+        super(BaseSigmoid, self).__init__()
+
+
+class BaseSoftmax(BaseLayer):
+    def __init__(self):
+        super(BaseSoftmax, self).__init__()
+
+
+###############################################################################
 class BaseTrueDiv(BaseLayer):
-    """Applies element wise division"""
+    """Apply reald-valued division to input tensor elementwise"""
     def __init__(self, denom, dtype=None):
         super(BaseTrueDiv, self).__init__(denom=denom, dtype=None)
         self.denom = None
 
 
-class BaseBatchNormalization(BaseLayer):
-    """Applies batch normalization
+class BaseFlatten(BaseLayer):
+    """Reshape 4D tensor into 2D tensor"""
+    def __init__(self):
+        super(BaseFlatten, self).__init__()
 
-    Ioffe, Sergey and Szegedy, Christian (2015):
+
+###############################################################################
+class BaseBatchNormalization(BaseLayer):
+    """Apply batch normalization [1]_:
+
+    .. math::
+        y = \\frac{x - \\mu}{\\sqrt{\\sigma^2 + \\epsilon}} \\gamma + \\beta
+
+    References
+    ----------
+    .. [1] Ioffe, Sergey and Szegedy, Christian (2015):
            Batch Normalization: Accelerating Deep Network Training by Reducing
            Internal Covariate Shift. http://arxiv.org/abs/1502.03167.
+
     """
     def __init__(self, scale=1.0, offset=0.0, epsilon=1e-4,
                  learn=True, decay=0.999):
         super(BaseBatchNormalization, self).__init__(
             decay=decay, epsilon=epsilon,
             scale=scale, offset=offset, learn=learn)
+
+        self._axes = self._pattern = None
+
+
+###############################################################################
+class BaseNHWC2NCHW(BaseLayer):
+    """Convert NCHW data from to NHWC
+
+    Rearrange the order of axes in 4D tensor from NHWC to NCHW
+    """
+    def __init__(self):
+        super(BaseNHWC2NCHW, self).__init__()
+
+
+class BaseNCHW2NHWC(BaseLayer):
+    """Convert NCHW data flow to NHWC
+
+    Rearrange the order of axes in 4D tensor from NCHW to NHWC
+    """
+    def __init__(self):
+        super(BaseNCHW2NHWC, self).__init__()

--- a/luchador/nn/core/base/q_learning.py
+++ b/luchador/nn/core/base/q_learning.py
@@ -46,12 +46,15 @@ class DeepQLearning(StoreMixin, object):
 
         # Actual NN models
         self.pre_trans_net = None
-        self.pre_trans_net = None
+        self.post_trans_net = None
 
         # Q values
+        self.future_reward = None
         self.predicted_q = None
         self.target_q = None
+        self.error = None
 
+        # Sync operation
         self.sync_op = None
 
     def _validate_args(self, args):

--- a/luchador/nn/core/base/wrapper.py
+++ b/luchador/nn/core/base/wrapper.py
@@ -8,7 +8,7 @@ class TensorWrapper(object):
 
     This class was introduced to provide easy shape inference to Theano Tensors
     while having the common interface for both Theano and Tensorflow.
-    `get` method provides access to the underlying object.
+    `unwrap` method provides access to the underlying object.
     """
     def __init__(self, tensor, shape, name, dtype):
         self._tensor = tensor

--- a/luchador/nn/core/base/wrapper.py
+++ b/luchador/nn/core/base/wrapper.py
@@ -16,9 +16,6 @@ class TensorWrapper(object):
         self.name = name
         self.dtype = dtype
 
-    def get_shape(self):
-        return self.shape
-
     def unwrap(self):
         """Get the underlying tensor object"""
         return self._tensor

--- a/luchador/nn/core/tensorflow/layer.py
+++ b/luchador/nn/core/tensorflow/layer.py
@@ -84,7 +84,7 @@ class Dense(LayerMixin, base_layer.BaseDense):
     def _build(self, input_tensor):
         _LG.debug('    Building {}: {}'.format(type(self).__name__, self.args))
         if not self.parameter_variables:
-            self._instantiate_parameter_variables(input_tensor.get_shape()[1])
+            self._instantiate_parameter_variables(input_tensor.shape[1])
 
         weight = self._get_parameter('weight').unwrap()
         output = tf.matmul(input_tensor.unwrap(), weight)
@@ -225,7 +225,7 @@ class Conv2D(LayerMixin, base_layer.BaseConv2D):
     def _build(self, input_tensor):
         _LG.debug('    Building {}: {}'.format(type(self).__name__, self.args))
         if not self.parameter_variables:
-            self._instantiate_parameter_variables(input_tensor.get_shape())
+            self._instantiate_parameter_variables(input_tensor.shape)
 
         weight = self._get_parameter('weight').unwrap()
         strides = self._get_strides()
@@ -273,7 +273,7 @@ class Flatten(LayerMixin, base_layer.BaseFlatten):
     """Implement Flatten in Tensorflow"""
     def _build(self, input_tensor):
         _LG.debug('    Building {}: {}'.format(type(self).__name__, self.args))
-        in_shape = input_tensor.get_shape()
+        in_shape = input_tensor.shape
         n_nodes = reduce(lambda prod, dim: prod*dim, in_shape[1:], 1)
         out_shape = (-1, n_nodes)
         output = tf.reshape(input_tensor.unwrap(), out_shape, 'output')
@@ -325,7 +325,7 @@ class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
 
     def _build(self, input_tensor):
         _LG.debug('    Building {}: {}'.format(type(self).__name__, self.args))
-        input_shape = input_tensor.get_shape()
+        input_shape = input_tensor.shape
         if not self.parameter_variables:
             self._instantiate_parameter_variables(input_shape)
 

--- a/luchador/nn/core/tensorflow/q_learning.py
+++ b/luchador/nn/core/tensorflow/q_learning.py
@@ -72,7 +72,7 @@ class DeepQLearning(BaseQLI):
             future = tf.add(rewards, post_q, name='future_reward')
 
         with tf.name_scope('target_q_value'):
-            n_actions = self.pre_trans_net.output.get_shape()[1]
+            n_actions = self.pre_trans_net.output.shape[1]
             with tf.name_scope('reshape_current_q_value'):
                 mask_off = tf.one_hot(actions, depth=n_actions, on_value=0.,
                                       off_value=1., name='actions_not_taken')

--- a/luchador/nn/core/theano/cost.py
+++ b/luchador/nn/core/theano/cost.py
@@ -1,3 +1,5 @@
+"""Implement Cost classes in Theano"""
+
 from __future__ import absolute_import
 
 import logging
@@ -5,29 +7,26 @@ import logging
 import theano
 import theano.tensor as T
 
-from ..base import (
-    get_cost,
-    BaseCost,
-    BaseSSE2,
-)
-from .wrapper import Tensor
-
-_LG = logging.getLogger(__name__)
+from ..base import cost as base_cost
+from ..base import get_cost
+from . import wrapper
 
 __all__ = [
     'BaseCost', 'get_cost',
     'SSE2', 'SigmoidCrossEntropy',
 ]
 
+_LG = logging.getLogger(__name__)
 
-def sum_mean(x):
+BaseCost = base_cost.BaseCost
+
+
+def _mean_sum(x):
     return x.sum(axis=1).mean()
 
 
-class SSE2(BaseSSE2):
-    """Compute Sum-Squared Error / 2
-    TODO: Add math expression
-    """
+class SSE2(base_cost.BaseSSE2):
+    """Implement SSE2 in Theano"""
     def _validate_args(self, args):
         if (
                 ('min_delta' in args and 'max_delta' in args) or
@@ -37,29 +36,25 @@ class SSE2(BaseSSE2):
         raise ValueError('When clipping delta, both '
                          '`min_delta` and `max_delta` must be provided')
 
-    def build(self, target, prediction):
+    def _build(self, target, prediction):
         target_, pred_ = target.unwrap(), prediction.unwrap()
         delta = theano.gradient.disconnected_grad(target_) - pred_
         if self.args['min_delta']:
             delta = delta.clip(self.args['min_delta'], self.args['max_delta'])
         delta = T.square(delta) / 2
 
-        if self.args['elementwise']:
-            output = Tensor(delta, shape=target.shape)
-        else:
-            output = Tensor(sum_mean(delta), shape=(1,))
-        return output
+        output = delta if self.args['elementwise'] else _mean_sum(delta)
+        shape = target.shape if self.args['elementwise'] else (1,)
+        return wrapper.Tensor(output, shape=shape)
 
 
-class SigmoidCrossEntropy(BaseCost):
-    """Apply sigmoid activation followed by cross entropy """
-    def build(self, target, logit):
+class SigmoidCrossEntropy(base_cost.BaseSigmoidCrossEntropy):
+    """Implement SCE in Theano"""
+    def _build(self, target, logit):
         x = logit.unwrap()
         z = theano.gradient.disconnected_grad(target.unwrap())
         ce = T.nnet.relu(x) - x * z + T.log(1 + T.exp(-abs(x)))
 
-        if self.args['elementwise']:
-            output = Tensor(ce, shape=target.shape)
-        else:
-            output = Tensor(sum_mean(ce), shape=(1,))
-        return output
+        output = ce if self.args['elementwise'] else _mean_sum(ce)
+        shape = target.shape if self.args['elementwise'] else (1,)
+        return wrapper.Tensor(output, shape=shape)

--- a/luchador/nn/core/theano/cost.py
+++ b/luchador/nn/core/theano/cost.py
@@ -45,7 +45,7 @@ class SSE2(BaseSSE2):
         delta = T.square(delta) / 2
 
         if self.args['elementwise']:
-            output = Tensor(delta, shape=target.get_shape())
+            output = Tensor(delta, shape=target.shape)
         else:
             output = Tensor(sum_mean(delta), shape=(1,))
         return output
@@ -59,7 +59,7 @@ class SigmoidCrossEntropy(BaseCost):
         ce = T.nnet.relu(x) - x * z + T.log(1 + T.exp(-abs(x)))
 
         if self.args['elementwise']:
-            output = Tensor(ce, shape=target.get_shape())
+            output = Tensor(ce, shape=target.shape)
         else:
             output = Tensor(sum_mean(ce), shape=(1,))
         return output

--- a/luchador/nn/core/theano/layer.py
+++ b/luchador/nn/core/theano/layer.py
@@ -32,15 +32,7 @@ BaseLayer = base_layer.BaseLayer
 
 class LayerMixin(object):
     """Implement common Layer methods in Theano"""
-    def get_update_operation(self):
-        """Get operation which updates Layer parameter
-
-        For layers which require updates other than back propagate
-        optimization, Operation returned by this function must be
-        fed to Session.run function.
-
-        Currently only BatchNormalization requires such operation.
-        """
+    def _get_update_operation(self):
         return wrapper.Operation(self.update_operations)
 
 
@@ -83,7 +75,6 @@ class Dense(LayerMixin, base_layer.BaseDense):
                 name='bias', shape=b_shape, initializer=b_init))
 
     def _build(self, input_tensor):
-        _LG.debug('    Building %s: %s', type(self).__name__, self.args)
         input_shape = input_tensor.shape
 
         if not len(input_shape) == 2:
@@ -248,7 +239,6 @@ class Conv2D(LayerMixin, base_layer.BaseConv2D):
             4D Tensor with shape (batch, #output channel, row, col)
         """
         input_shape = input_tensor.shape
-        _LG.debug('    Building %s: %s', type(self).__name__, self.args)
         _LG.debug('    input_shape: %s', input_shape)
         _LG.debug('    border_mode: %s', self._get_border_mode())
 
@@ -283,7 +273,6 @@ class ReLU(LayerMixin, base_layer.BaseReLU):
     """Implement ReLU layer in Theano"""
     def _build(self, input_tensor):
         """Build rectified linear activation operation on input tensor"""
-        _LG.debug('    Building %s: %s', type(self).__name__, self.args)
         input_shape = input_tensor.shape
         output_tensor = T.nnet.relu(input_tensor.unwrap())
         return _wrap_output(output_tensor, input_shape, name='output')
@@ -292,7 +281,6 @@ class ReLU(LayerMixin, base_layer.BaseReLU):
 class Sigmoid(LayerMixin, base_layer.BaseSigmoid):
     """Implement Sigmoid layer in Theano"""
     def _build(self, input_tensor):
-        _LG.debug('    Building %s: %s', type(self).__name__, self.args)
         input_shape = input_tensor.shape
         output_tensor = T.nnet.sigmoid(input_tensor.unwrap())
         return _wrap_output(output_tensor, input_shape, name='output')
@@ -301,7 +289,6 @@ class Sigmoid(LayerMixin, base_layer.BaseSigmoid):
 class Softmax(LayerMixin, base_layer.BaseSoftmax):
     """Implement Softmax layer in Theano"""
     def _build(self, input_tensor):
-        _LG.debug('    Building %s: %s', type(self).__name__, self.args)
         input_shape = input_tensor.shape
         output_tensor = T.nnet.softmax(input_tensor.unwrap())
         return _wrap_output(output_tensor, input_shape, name='output')
@@ -314,7 +301,6 @@ class Flatten(LayerMixin, base_layer.BaseFlatten):
         input_shape = input_tensor.shape
         n_nodes = int(reduce(lambda r, d: r*d, input_shape[1:], 1))
 
-        _LG.debug('    Building %s: %s', type(self).__name__, self.args)
         _LG.debug('    Input shape: %s', input_shape)
         _LG.debug('    #Nodes     : %s', n_nodes)
 
@@ -332,7 +318,6 @@ class TrueDiv(LayerMixin, base_layer.BaseTrueDiv):
             self.args['denom'], dtype=dtype, name='denominator')
 
     def _build(self, input_tensor):
-        _LG.debug('    Building %s: %s', type(self).__name__, self.args)
         if self.denom is None:
             self._instantiate_denominator()
         output_tensor = input_tensor.unwrap() / self.args['denom']
@@ -372,7 +357,6 @@ class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
         self._add_parameter('offset', offset)
 
     def _build(self, input_tensor):
-        _LG.debug('    Building %s: %s', type(self).__name__, self.args)
         if not self.parameter_variables:
             self._instantiate_parameters(input_tensor.shape)
 

--- a/luchador/nn/core/theano/layer.py
+++ b/luchador/nn/core/theano/layer.py
@@ -84,7 +84,7 @@ class Dense(LayerMixin, base_layer.BaseDense):
 
     def _build(self, input_tensor):
         _LG.debug('    Building %s: %s', type(self).__name__, self.args)
-        input_shape = input_tensor.get_shape()
+        input_shape = input_tensor.shape
 
         if not len(input_shape) == 2:
             raise ValueError('Input tensor must be 2D. '
@@ -247,7 +247,7 @@ class Conv2D(LayerMixin, base_layer.BaseConv2D):
         Tensor
             4D Tensor with shape (batch, #output channel, row, col)
         """
-        input_shape = input_tensor.get_shape()
+        input_shape = input_tensor.shape
         _LG.debug('    Building %s: %s', type(self).__name__, self.args)
         _LG.debug('    input_shape: %s', input_shape)
         _LG.debug('    border_mode: %s', self._get_border_mode())
@@ -284,7 +284,7 @@ class ReLU(LayerMixin, base_layer.BaseReLU):
     def _build(self, input_tensor):
         """Build rectified linear activation operation on input tensor"""
         _LG.debug('    Building %s: %s', type(self).__name__, self.args)
-        input_shape = input_tensor.get_shape()
+        input_shape = input_tensor.shape
         output_tensor = T.nnet.relu(input_tensor.unwrap())
         return _wrap_output(output_tensor, input_shape, name='output')
 
@@ -293,7 +293,7 @@ class Sigmoid(LayerMixin, base_layer.BaseSigmoid):
     """Implement Sigmoid layer in Theano"""
     def _build(self, input_tensor):
         _LG.debug('    Building %s: %s', type(self).__name__, self.args)
-        input_shape = input_tensor.get_shape()
+        input_shape = input_tensor.shape
         output_tensor = T.nnet.sigmoid(input_tensor.unwrap())
         return _wrap_output(output_tensor, input_shape, name='output')
 
@@ -302,7 +302,7 @@ class Softmax(LayerMixin, base_layer.BaseSoftmax):
     """Implement Softmax layer in Theano"""
     def _build(self, input_tensor):
         _LG.debug('    Building %s: %s', type(self).__name__, self.args)
-        input_shape = input_tensor.get_shape()
+        input_shape = input_tensor.shape
         output_tensor = T.nnet.softmax(input_tensor.unwrap())
         return _wrap_output(output_tensor, input_shape, name='output')
 
@@ -311,7 +311,7 @@ class Softmax(LayerMixin, base_layer.BaseSoftmax):
 class Flatten(LayerMixin, base_layer.BaseFlatten):
     """Implement Flatten layer in Theano"""
     def _build(self, input_tensor):
-        input_shape = input_tensor.get_shape()
+        input_shape = input_tensor.shape
         n_nodes = int(reduce(lambda r, d: r*d, input_shape[1:], 1))
 
         _LG.debug('    Building %s: %s', type(self).__name__, self.args)
@@ -336,7 +336,7 @@ class TrueDiv(LayerMixin, base_layer.BaseTrueDiv):
         if self.denom is None:
             self._instantiate_denominator()
         output_tensor = input_tensor.unwrap() / self.args['denom']
-        return _wrap_output(output_tensor, input_tensor.get_shape(), 'output')
+        return _wrap_output(output_tensor, input_tensor.shape, 'output')
 
 
 ###############################################################################
@@ -374,7 +374,7 @@ class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
     def _build(self, input_tensor):
         _LG.debug('    Building %s: %s', type(self).__name__, self.args)
         if not self.parameter_variables:
-            self._instantiate_parameters(input_tensor.get_shape())
+            self._instantiate_parameters(input_tensor.shape)
 
         input_tensor_ = input_tensor.unwrap()
 
@@ -404,7 +404,7 @@ class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
 
         stdi = T.inv(T.sqrt(var_acc + self.args['epsilon']))
         output = scale * (input_tensor_ - mean_acc) * stdi + offset
-        return _wrap_output(output, input_tensor.get_shape(), 'output')
+        return _wrap_output(output, input_tensor.shape, 'output')
 
 
 ###############################################################################
@@ -413,7 +413,7 @@ class NHWC2NCHW(LayerMixin, base_layer.BaseNHWC2NCHW):
         input_tensor_ = input_tensor.unwrap()
         output_tensor_ = input_tensor_.dimshuffle(0, 3, 1, 2)
 
-        shape = input_tensor.get_shape()
+        shape = input_tensor.shape
         output_shape = (shape[0], shape[3], shape[1], shape[2])
         return _wrap_output(output_tensor_, output_shape, 'output')
 
@@ -423,6 +423,6 @@ class NCHW2NHWC(LayerMixin, base_layer.BaseNCHW2NHWC):
         input_tensor_ = input_tensor.unwrap()
         output_tensor_ = input_tensor_.dimshuffle(0, 2, 3, 1)
 
-        shape = input_tensor.get_shape()
+        shape = input_tensor.shape
         output_shape = (shape[0], shape[2], shape[3], shape[1])
         return _wrap_output(output_tensor_, output_shape, 'output')

--- a/luchador/nn/core/theano/q_learning.py
+++ b/luchador/nn/core/theano/q_learning.py
@@ -64,7 +64,7 @@ class DeepQLearning(BaseQLI):
             rewards = rewards.clip(min_reward, max_reward)
         future = rewards + post_q
 
-        n_actions = self.pre_trans_net.output.get_shape()[1]
+        n_actions = self.pre_trans_net.output.shape[1]
         mask_on = T.extra_ops.to_one_hot(actions, n_actions)
         mask_off = 1.0 - mask_on
         current = self.pre_trans_net.output.unwrap()

--- a/tests/unit/agent/recorder_test.py
+++ b/tests/unit/agent/recorder_test.py
@@ -376,7 +376,6 @@ class TestTransitionRecorder(unittest.TestCase):
         """Last observations are retrieved in "NHWC" format"""
         self._test_get_current_state('NHWC')
 
-    @unittest.skipIf('CIRCLECI' in os.environ, 'Skipping sampling time')
     def test_sampling_time(self):
         """Sampling should finish in reasonable time."""
         height, width = 1, 1
@@ -400,8 +399,10 @@ class TestTransitionRecorder(unittest.TestCase):
             tr.sample(n_samples)
         dt = (time.time() - t0) / n_repeats
         print('{} [sec]'.format(dt))
+
+        threshold = 0.0010 if 'CIRCLECI' in os.environ else 0.0005
         self.assertTrue(
-            dt < 0.0008,
+            dt < threshold,
             'Sampling is taking too much time ({} sec). '
             'Review implementation.'.format(dt)
         )


### PR DESCRIPTION
Defining class public method in backends cause duplication of code and documentation.
So put all public interface in base and backend only implements hidden methods.
