### PR TITLE
Move importing of Base* and get_* to base

### DIFF
--- a/luchador/nn/core/__init__.py
+++ b/luchador/nn/core/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 import luchador
 
+from .base import *  # noqa: F401, F403
 
 logging.getLogger(__name__).info(
     'Using %s backend', luchador.get_nn_backend()

--- a/luchador/nn/core/base/__init__.py
+++ b/luchador/nn/core/base/__init__.py
@@ -2,11 +2,8 @@
 
 from __future__ import absolute_import
 
-from .session import *  # noqa: F401, F403
-from .layer import *  # noqa: F401, F403
-from .cost import *  # noqa: F401, F403
-from .wrapper import *  # noqa: F401, F403
+from .layer import BaseLayer, get_layer  # noqa: F401
+from .cost import BaseCost, get_cost  # noqa: F401
 
-from .initializer import *  # noqa: F401, F403
-from .optimizer import *  # noqa: F401, F403
-from .q_learning import *  # noqa: F401, F403
+from .initializer import BaseInitializer, get_initializer  # noqa: F401
+from .optimizer import BaseOptimizer, get_optimizer  # noqa: F401

--- a/luchador/nn/core/base/cost.py
+++ b/luchador/nn/core/base/cost.py
@@ -7,10 +7,6 @@ import logging
 
 from luchador import common
 
-__all__ = [
-    'BaseCost', 'get_cost',
-    'BaseSSE2', 'BaseSigmoidCrossEntropy',
-]
 
 _LG = logging.getLogger(__name__)
 

--- a/luchador/nn/core/base/initializer.py
+++ b/luchador/nn/core/base/initializer.py
@@ -7,8 +7,6 @@ from luchador import common
 
 _LG = logging.getLogger(__name__)
 
-__all__ = ['BaseInitializer', 'get_initializer']
-
 
 class BaseInitializer(common.SerializeMixin, object):
     """Common interface for Initializer classes"""

--- a/luchador/nn/core/base/layer.py
+++ b/luchador/nn/core/base/layer.py
@@ -11,15 +11,6 @@ from luchador import common
 
 _LG = logging.getLogger(__name__)
 
-__all__ = [
-    'BaseLayer', 'get_layer',
-    'BaseDense', 'BaseConv2D',
-    'BaseReLU', 'BaseSigmoid', 'BaseSoftmax',
-    'BaseTrueDiv', 'BaseFlatten',
-    'BaseBatchNormalization',
-    'BaseNCHW2NHWC', 'BaseNHWC2NCHW',
-]
-
 
 class BaseLayer(common.SerializeMixin, object):
     """Defines common interface (copy and build) for Layer classes"""

--- a/luchador/nn/core/base/optimizer.py
+++ b/luchador/nn/core/base/optimizer.py
@@ -6,13 +6,6 @@ import abc
 
 from luchador import common
 
-__all__ = [
-    'BaseOptimizer', 'get_optimizer',
-    'BaseSGD',
-    'BaseRMSProp', 'BaseNeonRMSProp', 'BaseGravesRMSProp',
-    'BaseAdam', 'BaseAdamax',
-]
-
 
 class BaseOptimizer(common.SerializeMixin):
     """Define common interface of Optimizer"""

--- a/luchador/nn/core/base/q_learning.py
+++ b/luchador/nn/core/base/q_learning.py
@@ -5,7 +5,6 @@ import logging
 
 from luchador import common
 
-__all__ = ['BaseDeepQLearning']
 
 _LG = logging.getLogger(__name__)
 

--- a/luchador/nn/core/base/session.py
+++ b/luchador/nn/core/base/session.py
@@ -9,8 +9,6 @@ from collections import OrderedDict
 import h5py
 import numpy as np
 
-__all__ = ['BaseSession']
-
 _LG = logging.getLogger(__name__)
 
 

--- a/luchador/nn/core/base/wrapper.py
+++ b/luchador/nn/core/base/wrapper.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 
 
-__all__ = ['BaseTensor', 'Operation']
-
-
 class BaseTensor(object):
     """Wraps Tensor or Variable object in Theano/Tensorflow
 

--- a/luchador/nn/core/tensorflow/cost.py
+++ b/luchador/nn/core/tensorflow/cost.py
@@ -7,13 +7,7 @@ import tensorflow as tf
 from ..base import cost as base_cost
 from . import wrapper
 
-__all__ = [
-    'BaseCost', 'get_cost',
-    'SSE2', 'SigmoidCrossEntropy',
-]
-
-get_cost = base_cost.get_cost
-BaseCost = base_cost.BaseCost
+__all__ = ['SSE2', 'SigmoidCrossEntropy']
 
 
 def _mean_sum(err):

--- a/luchador/nn/core/tensorflow/initializer.py
+++ b/luchador/nn/core/tensorflow/initializer.py
@@ -7,12 +7,9 @@ import luchador
 from ..base import initializer as base_initializer
 
 __all__ = [
-    'BaseInitializer', 'get_initializer',
+    'TFInitializerMixin',
     'Constant', 'Normal', 'Uniform', 'Xavier', 'XavierConv2D'
 ]
-
-get_initializer = base_initializer.get_initializer
-BaseInitializer = base_initializer.BaseInitializer
 
 
 class TFInitializerMixin(object):
@@ -28,14 +25,14 @@ class TFInitializerMixin(object):
         pass
 
 
-class Constant(TFInitializerMixin, BaseInitializer):
+class Constant(TFInitializerMixin, base_initializer.BaseInitializer):
     def __init__(self, value, dtype=None):
         super(Constant, self).__init__(value=value, dtype=dtype)
         dtype = tf.as_dtype(dtype or luchador.get_nn_dtype())
         self._initializer = tf.constant_initializer(value=value, dtype=dtype)
 
 
-class Normal(TFInitializerMixin, BaseInitializer):
+class Normal(TFInitializerMixin, base_initializer.BaseInitializer):
     def __init__(self, mean=0.0, stddev=1.0, seed=None, dtype=None):
         super(Normal, self).__init__(
             mean=mean, stddev=stddev, seed=seed, dtype=dtype)
@@ -44,7 +41,7 @@ class Normal(TFInitializerMixin, BaseInitializer):
             mean=mean, stddev=stddev, seed=seed, dtype=dtype)
 
 
-class Uniform(TFInitializerMixin, BaseInitializer):
+class Uniform(TFInitializerMixin, base_initializer.BaseInitializer):
     def __init__(self, minval=0.0, maxval=1.0, seed=None, dtype=None):
         super(Uniform, self).__init__(
             minval=minval, maxval=maxval, seed=seed, dtype=dtype)
@@ -53,7 +50,7 @@ class Uniform(TFInitializerMixin, BaseInitializer):
             minval=minval, maxval=maxval, seed=seed, dtype=dtype)
 
 
-class Xavier(TFInitializerMixin, BaseInitializer):
+class Xavier(TFInitializerMixin, base_initializer.BaseInitializer):
     def __init__(self, uniform=True, seed=None, dtype=None):
         super(Xavier, self).__init__(
             uniform=uniform, seed=seed, dtype=dtype)
@@ -62,7 +59,7 @@ class Xavier(TFInitializerMixin, BaseInitializer):
             uniform=uniform, seed=seed, dtype=dtype)
 
 
-class XavierConv2D(TFInitializerMixin, BaseInitializer):
+class XavierConv2D(TFInitializerMixin, base_initializer.BaseInitializer):
     def __init__(self, uniform=True, seed=None, dtype=None):
         super(XavierConv2D, self).__init__(
             uniform=uniform, seed=seed, dtype=dtype)

--- a/luchador/nn/core/tensorflow/layer.py
+++ b/luchador/nn/core/tensorflow/layer.py
@@ -9,23 +9,23 @@ import warnings
 import tensorflow as tf
 
 import luchador
-from ..base import layer as base_layer
+from ..base import (
+    layer as base_layer,
+    initializer as base_init,
+)
 from . import scope, wrapper, initializer
 
 
 _LG = logging.getLogger(__name__)
 
 __all__ = [
-    'BaseLayer', 'LayerMixin', 'get_layer',
+    'LayerMixin',
     'Dense', 'Conv2D',
     'ReLU', 'Sigmoid', 'Softmax',
     'Flatten', 'TrueDiv',
     'BatchNormalization',
     'NHWC2NCHW', 'NCHW2NHWC',
 ]
-
-get_layer = base_layer.get_layer
-BaseLayer = base_layer.BaseLayer
 
 
 class LayerMixin(object):
@@ -47,13 +47,13 @@ class Dense(LayerMixin, base_layer.BaseDense):
 
         cfg = init_cfg.get('weight')
         self.initializers['weight'] = (
-            initializer.get_initializer(cfg['name'])(**cfg['args'])
+            base_init.get_initializer(cfg['name'])(**cfg['args'])
             if cfg else initializer.Xavier()
         )
         if self.args['with_bias']:
             cfg = init_cfg.get('bias')
             self.initializers['bias'] = (
-                initializer.get_initializer(cfg['name'])(**cfg['args'])
+                base_init.get_initializer(cfg['name'])(**cfg['args'])
                 if cfg else initializer.Constant(0.1)
             )
 
@@ -184,14 +184,14 @@ class Conv2D(LayerMixin, base_layer.BaseConv2D):
 
         cfg = init_cfg.get('weight')
         self.initializers['weight'] = (
-            initializer.get_initializer(cfg['name'])(**cfg['args'])
+            base_init.get_initializer(cfg['name'])(**cfg['args'])
             if cfg else initializer.XavierConv2D()
         )
 
         if self.args['with_bias']:
             cfg = init_cfg.get('bias')
             self.initializers['bias'] = (
-                initializer.get_initializer(cfg['name'])(**cfg['args'])
+                base_init.get_initializer(cfg['name'])(**cfg['args'])
                 if cfg else initializer.Constant(0.1)
             )
 

--- a/luchador/nn/core/tensorflow/optimizer.py
+++ b/luchador/nn/core/tensorflow/optimizer.py
@@ -7,14 +7,10 @@ from ..base import optimizer as base_optimizer
 from . import scope, initializer, wrapper
 
 __all__ = [
-    'BaseOptimizer', 'get_optimizer',
     'SGD',
     'RMSProp', 'GravesRMSProp', 'NeonRMSProp',
     'Adam', 'Adamax',
 ]
-
-get_optimizer = base_optimizer.get_optimizer
-BaseOptimizer = base_optimizer.BaseOptimizer
 
 
 def _parse_kwargs(kwargs):

--- a/luchador/nn/core/tensorflow/scope.py
+++ b/luchador/nn/core/tensorflow/scope.py
@@ -4,10 +4,7 @@ import tensorflow as tf
 
 import luchador
 from .. import initializer as base_init_mod
-from . import (
-    wrapper,
-    initializer as init_mod
-)
+from . import wrapper
 
 __all__ = ['name_scope', 'get_variable', 'variable_scope',
            'VariableScope', 'get_variable_scope']

--- a/luchador/nn/core/tensorflow/scope.py
+++ b/luchador/nn/core/tensorflow/scope.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 import tensorflow as tf
 
-from luchador import get_nn_dtype
+import luchador
+from .. import initializer as base_init_mod
 from . import (
     wrapper,
     initializer as init_mod
@@ -41,7 +42,7 @@ def get_variable(name, shape=None, dtype=None,
       For other arguments, see
       https://www.tensorflow.org/versions/master/api_docs/python/state_ops.html#get_variable
     """
-    if isinstance(initializer, init_mod.BaseInitializer):
+    if isinstance(initializer, base_init_mod.BaseInitializer):
         initializer = initializer.unwrap()
 
     scope = tf.get_variable_scope()
@@ -56,7 +57,7 @@ def get_variable(name, shape=None, dtype=None,
             )
         return var
     else:
-        dtype = dtype or get_nn_dtype()
+        dtype = dtype or luchador.get_nn_dtype()
 
         variable = tf.get_variable(
             name, shape=shape, dtype=dtype, initializer=initializer,

--- a/luchador/nn/core/theano/cost.py
+++ b/luchador/nn/core/theano/cost.py
@@ -10,15 +10,9 @@ import theano.tensor as T
 from ..base import cost as base_cost
 from . import wrapper
 
-__all__ = [
-    'BaseCost', 'get_cost',
-    'SSE2', 'SigmoidCrossEntropy',
-]
+__all__ = ['SSE2', 'SigmoidCrossEntropy']
 
 _LG = logging.getLogger(__name__)
-
-get_cost = base_cost.get_cost
-BaseCost = base_cost.BaseCost
 
 
 def _mean_sum(x):

--- a/luchador/nn/core/theano/initializer.py
+++ b/luchador/nn/core/theano/initializer.py
@@ -9,16 +9,10 @@ from theano import config
 from ..base import initializer as base_initializer
 from . import random
 
-__all__ = [
-    'BaseInitializer', 'get_initializer',
-    'Constant', 'Normal', 'Uniform', 'Xavier', 'XavierConv2D',
-]
-
-get_initializer = base_initializer.get_initializer
-BaseInitializer = base_initializer.BaseInitializer
+__all__ = ['Constant', 'Normal', 'Uniform', 'Xavier', 'XavierConv2D']
 
 
-class Constant(BaseInitializer):
+class Constant(base_initializer.BaseInitializer):
     """Initialize variale with constant value
 
     Parameters
@@ -37,7 +31,7 @@ class Constant(BaseInitializer):
         return self.args['value'] * np.ones(shape, dtype=dtype)
 
 
-class Uniform(BaseInitializer):
+class Uniform(base_initializer.BaseInitializer):
     def __init__(self, minval=0.0, maxval=1.0, seed=None, dtype=None):
         super(Uniform, self).__init__(
             minval=minval, maxval=maxval, seed=seed, dtype=dtype)
@@ -50,7 +44,7 @@ class Uniform(BaseInitializer):
         return values.astype(dtype)
 
 
-class Normal(BaseInitializer):
+class Normal(base_initializer.BaseInitializer):
     def __init__(self, mean=0.0, stddev=1.0, seed=None, dtype=None):
         super(Normal, self).__init__(
             mean=mean, stddev=stddev, seed=seed, dtype=dtype)
@@ -63,7 +57,7 @@ class Normal(BaseInitializer):
         return values.astype(dtype)
 
 
-class Xavier(BaseInitializer):
+class Xavier(base_initializer.BaseInitializer):
     """Adoptation of xavier_initializer from tensorflow"""
     def __init__(self, uniform=True, seed=None, dtype=None):
         super(Xavier, self).__init__(uniform=uniform, seed=seed, dtype=dtype)

--- a/luchador/nn/core/theano/layer.py
+++ b/luchador/nn/core/theano/layer.py
@@ -8,12 +8,15 @@ import logging
 import theano
 import theano.tensor as T
 
-from ..base import layer as base_layer
+from ..base import (
+    layer as base_layer,
+    initializer as base_init,
+)
 from . import scope, wrapper, initializer
 
 
 __all__ = [
-    'BaseLayer', 'LayerMixin', 'get_layer',
+    'LayerMixin',
     'Dense', 'Conv2D',
     'ReLU', 'Sigmoid', 'Softmax',
     'Flatten', 'TrueDiv',
@@ -22,9 +25,6 @@ __all__ = [
 ]
 
 _LG = logging.getLogger(__name__)
-
-get_layer = base_layer.get_layer
-BaseLayer = base_layer.BaseLayer
 
 
 class LayerMixin(object):
@@ -46,14 +46,14 @@ class Dense(LayerMixin, base_layer.BaseDense):
 
         cfg = init_cfg.get('weight')
         self.initializers['weight'] = (
-            initializer.get_initializer(cfg['name'])(**cfg['args'])
+            base_init.get_initializer(cfg['name'])(**cfg['args'])
             if cfg else initializer.Xavier()
         )
 
         if self.args['with_bias']:
             cfg = init_cfg.get('bias')
             self.initializers['bias'] = (
-                initializer.get_initializer(cfg['name'])(**cfg['args'])
+                base_init.get_initializer(cfg['name'])(**cfg['args'])
                 if cfg else initializer.Constant(0.1)
             )
 
@@ -147,14 +147,14 @@ class Conv2D(LayerMixin, base_layer.BaseConv2D):
 
         cfg = init_cfg.get('weight')
         self.initializers['weight'] = (
-            initializer.get_initializer(cfg['name'])(**cfg['args'])
+            base_init.get_initializer(cfg['name'])(**cfg['args'])
             if cfg else initializer.XavierConv2D()
         )
 
         if self.args['with_bias']:
             cfg = init_cfg.get('bias')
             self.initializers['bias'] = (
-                initializer.get_initializer(cfg['name'])(**cfg['args'])
+                base_init.get_initializer(cfg['name'])(**cfg['args'])
                 if cfg else initializer.Constant(0.1)
             )
 

--- a/luchador/nn/core/theano/optimizer.py
+++ b/luchador/nn/core/theano/optimizer.py
@@ -10,14 +10,10 @@ from ..base import optimizer as base_opt
 from . import scope, initializer, wrapper
 
 __all__ = [
-    'BaseOptimizer', 'get_optimizer',
     'SGD',
     'RMSProp', 'GravesRMSProp', 'NeonRMSProp',
     'Adam', 'Adamax',
 ]
-
-get_optimizer = base_opt.get_optimizer
-BaseOptimizer = base_opt.BaseOptimizer
 
 
 class TheanoOptimizerMixin(object):

--- a/luchador/nn/core/theano/session.py
+++ b/luchador/nn/core/theano/session.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 import theano
 import numpy as np
 
-from luchador.common import is_iteratable
+from luchador import common
 from ..base import session
 from . import scope, wrapper
 
@@ -28,7 +28,7 @@ def _parse_inputs(inputs):
     if inputs is None:
         return inputs_
 
-    if not is_iteratable(inputs):
+    if not common.is_iteratable(inputs):
         inputs = [inputs]
 
     try:
@@ -44,7 +44,7 @@ def _parse_inputs(inputs):
 def _parse_outputs(outputs):
     if outputs is None:
         return []
-    if not is_iteratable(outputs):
+    if not common.is_iteratable(outputs):
         outputs = [outputs]
     return [o.unwrap() for o in outputs]
 
@@ -54,7 +54,7 @@ def _parse_updates(updates):
     if updates is None:
         return ret
 
-    if not is_iteratable(updates):
+    if not common.is_iteratable(updates):
         updates = [updates]
 
     for update in updates:
@@ -98,7 +98,7 @@ class Session(session.BaseSession):
             self.functions[name] = function
 
         values = function(*inputs.values())
-        if is_iteratable(outputs):
+        if common.is_iteratable(outputs):
             return values
         return values[0]
 


### PR DESCRIPTION
Previously `Base*` classes and corresponding `get_*` functions were defined in `nn.base` and imported in `nn.theano` or `nn.tensorflow`, then exposed again by these modules.

This clutters code base and documentation. So these base classes and functions are imported and exposed by `nn` module directly.
