### PR TITLE
Make environment impor lazy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ dependencies:
     - "Arcade-Learning-Environment"
   pre:
     - sudo apt-get update
+    - git fetch --unshallow origin || true
     - ./cci_script/install_dependencies.sh
     - ./cci_script/fix_urllib_sni.sh
   override:

--- a/luchador/env/__init__.py
+++ b/luchador/env/__init__.py
@@ -1,12 +1,3 @@
 from __future__ import absolute_import
 
-import logging
-
 from .base import *  # noqa: F401, F403
-
-try:
-    from .ale import *  # noqa: F401, F403
-except ImportError:
-    logging.getLogger(__name__).exception('Failed to import ALE Environment.')
-
-from .flappy_bird import *  # noqa: F401, F403

--- a/luchador/env/base.py
+++ b/luchador/env/base.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import abc
+import importlib
 
 import numpy as np
 
@@ -118,6 +119,12 @@ class BaseEnvironment(object):
         pass
 
 
+_ENVIRONMENT_MODULE_MAPPING = {
+    'ALEEnvironment': 'ale',
+    'FlappyBird': 'flappy_bird',
+}
+
+
 def get_env(name):
     """Retrieve Environment class by name
 
@@ -136,7 +143,16 @@ def get_env(name):
     ValueError
         When Environment with the given name is not found
     """
+    # Some environments depend on dynamic library, and
+    # importing all of them at global initialization leads to TLS Error.
+    # TLS can be avoided only by upgrading underlying libc version, which
+    # is not easy. So we import such environments on-demand.
+    if name in _ENVIRONMENT_MODULE_MAPPING:
+        module = 'luchador.env.{:s}'.format(_ENVIRONMENT_MODULE_MAPPING[name])
+        importlib.import_module(module)
+
     for class_ in luchador.common.get_subclasses(BaseEnvironment):
         if class_.__name__ == name:
             return class_
+
     raise ValueError('Unknown Environment: {}'.format(name))

--- a/luchador/env/base.py
+++ b/luchador/env/base.py
@@ -144,8 +144,9 @@ def get_env(name):
         When Environment with the given name is not found
     """
     # Some environments depend on dynamic library, and
-    # importing all of them at global initialization leads to TLS Error.
-    # TLS can be avoided only by upgrading underlying libc version, which
+    # importing all of them at global initialization leads to TLS Error on
+    # Ubuntu 14.04.
+    # TLS Error is avoidable only by upgrading underlying libc version, which
     # is not easy. So we import such environments on-demand.
     if name in _ENVIRONMENT_MODULE_MAPPING:
         module = 'luchador.env.{:s}'.format(_ENVIRONMENT_MODULE_MAPPING[name])

--- a/tests/unit/env/ale/ale_test.py
+++ b/tests/unit/env/ale/ale_test.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from luchador.env import ALEEnvironment as ALE
+from luchador.env.ale import ALEEnvironment as ALE
 
 
 class ALEEnvironmentTest(unittest.TestCase):


### PR DESCRIPTION
Some environments depend on dynamic library, and importing all of them at global initialization leads to TLS Error on Ubuntu 14.04.
TLS Error is avoidable only by upgrading underlying libc version, which is not easy.
So we import such environments on-demand.