### PR TITLE
Fix theano optimization error function

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ test:
   pre:
     - pip install --upgrade flake8
     - pip install --upgrade coverage
-    - coverage erase
+    - coverage erase && rm -rf .coverage.*
     - mkdir -p tmp
   override:
     # Unit tests

--- a/tests/integration/run_dqn.sh
+++ b/tests/integration/run_dqn.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-
-set -e
+set -eux
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DATA_DIR="${BASE_DIR}/data/dqn"
 
-if [ "${COUNT_INTEGRATION_COVERAGE}" = true ]; then
+if [ "${COUNT_INTEGRATION_COVERAGE:-false}" = true ]; then
     TEST_COMMAND="coverage run --source luchador -a tool/profile.py"
 else
     TEST_COMMAND="luchador"

--- a/tests/integration/run_initializer_compatibility_test.sh
+++ b/tests/integration/run_initializer_compatibility_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -u
+set -eux
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DATA_DIR="${BASE_DIR}/data/initializer"

--- a/tests/integration/run_layer_numerical_compatibility_tests.sh
+++ b/tests/integration/run_layer_numerical_compatibility_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -u
+set -eux
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DATA_DIR="${BASE_DIR}/data/layer"

--- a/tests/integration/run_optimizer_numerical_compatibility_tests.sh
+++ b/tests/integration/run_optimizer_numerical_compatibility_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -eux
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TEST_DIR="${BASE_DIR}/test_optimizer_numerical_compatibility"

--- a/tests/integration/run_serialization_tests.sh
+++ b/tests/integration/run_serialization_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eux
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TEST_DIR="${BASE_DIR}/test_serialization"

--- a/tests/integration/test_initializer_compatibility/test_initializer_compatibility.sh
+++ b/tests/integration/test_initializer_compatibility/test_initializer_compatibility.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script runs the initialization of tensorflow and theano backend separately and write the result to files.
 # Then check if the difference between the results are within threshold
-set -u
+set -eux
 
 CONFIG=$1
 if [[ ! -f "${CONFIG}" ]]; then

--- a/tests/integration/test_layer_numerical_compatibility/test_layer_numerical_compatibility.sh
+++ b/tests/integration/test_layer_numerical_compatibility/test_layer_numerical_compatibility.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script runs the layer IO of tensorflow and theano backend separately and write the result to files.
 # Then check if the difference between the results are within threshold.
-set -eu
+set -eux
 
 CONFIG=${1}
 if [[ ! -f "${CONFIG}" ]]; then

--- a/tests/integration/test_optimizer_numerical_compatibility/test_optimizer_numerical_compatibility.sh
+++ b/tests/integration/test_optimizer_numerical_compatibility/test_optimizer_numerical_compatibility.sh
@@ -7,7 +7,7 @@
 # --optimizer: Name of optimizer configurations. See optimizer directory for the list of valid configurations.
 # --iterations: #parameter updates to execute before comparing the parameters. Default: 1000
 # --threshold: Maximum relative diff to allow
-set -eu
+set -eux
 
 while [[ $# -gt 0 ]]
 do

--- a/tests/integration/test_serialization/test_serialization.sh
+++ b/tests/integration/test_serialization/test_serialization.sh
@@ -4,8 +4,7 @@
 # Arguments:
 # --model: Name of model to tests [de]serialization.
 # --optimizer: Name of optimizer to test [de]serialization.
-
-set -eu
+set -eux
 
 while [[ $# -gt 0 ]]
 do

--- a/tests/integration/test_server_client/run_server_client.sh
+++ b/tests/integration/test_server_client/run_server_client.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-
-set -eu
+set -eux
 
 if [ ${COUNT_INTEGRATION_COVERAGE:-false} = true ]; then
     TEST_COMMAND1="coverage run --parallel-mode tool/profile.py"

--- a/tests/unit/fixture.py
+++ b/tests/unit/fixture.py
@@ -58,7 +58,7 @@ def get_all_costs():
 
 
 ###############################################################################
-def create_variable(shape, value=7, dtype='int32', name='var'):
+def create_variable(shape, dtype, value=7, name='var'):
     """Create Variable for test"""
     return nn.get_variable(
         name=name, shape=shape, dtype=dtype,
@@ -66,7 +66,7 @@ def create_variable(shape, value=7, dtype='int32', name='var'):
     )
 
 
-def create_tensor(shape, dtype='int32', name='tensor'):
+def create_tensor(shape, dtype, name='tensor'):
     """Create Tensor for test"""
     if luchador.get_nn_backend() == 'theano':
         import theano.tensor as be

--- a/tests/unit/nn/misc_test.py
+++ b/tests/unit/nn/misc_test.py
@@ -11,7 +11,7 @@ from tests.unit import fixture
 class TestMisc(unittest.TestCase):
     def _test_mean(self, axis, shape, keep_dims):
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor0 = fixture.create_tensor(shape)
+            tensor0 = fixture.create_tensor(shape, dtype='float32')
             tensor1 = nn.mean(tensor0, axis=axis, keep_dims=keep_dims)
 
         session = nn.Session()

--- a/tests/unit/nn/wrapper_test.py
+++ b/tests/unit/nn/wrapper_test.py
@@ -13,7 +13,7 @@ class TestTensorOps(unittest.TestCase):
     def test_mul_numbers(self):
         constant, shape = 10, (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
             tensor2 = tensor1 * constant
             tensor3 = constant * tensor1
 
@@ -28,7 +28,7 @@ class TestTensorOps(unittest.TestCase):
     def test_mul_tensor(self):
         shape = (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
             tensor2 = tensor1 * tensor1
 
         session = nn.Session()
@@ -41,8 +41,8 @@ class TestTensorOps(unittest.TestCase):
     def test_mul_variable(self):
         shape = (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
-            variable = fixture.create_variable(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
+            variable = fixture.create_variable(shape, dtype='int32')
             tensor2 = tensor1 * variable
             tensor3 = variable * tensor1
 
@@ -58,7 +58,7 @@ class TestTensorOps(unittest.TestCase):
     def test_mul_input(self):
         shape = (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
             input_ = nn.Input(name='input', shape=shape, dtype='int32')
             tensor2 = tensor1 * input_
             tensor3 = input_ * tensor1
@@ -77,7 +77,7 @@ class TestTensorOps(unittest.TestCase):
     def test_add_numbers(self):
         constant, shape = 10, (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
             tensor2 = tensor1 + constant
             tensor3 = constant + tensor1
 
@@ -92,7 +92,7 @@ class TestTensorOps(unittest.TestCase):
     def test_add_tensor(self):
         shape = (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
             tensor2 = tensor1 + tensor1
 
         session = nn.Session()
@@ -105,7 +105,7 @@ class TestTensorOps(unittest.TestCase):
         shape = (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
             input_ = nn.Input(shape=shape, dtype='int32')
-            tensor1 = fixture.create_tensor(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
             tensor2 = tensor1 + input_
             tensor3 = input_ + tensor1
 
@@ -121,8 +121,8 @@ class TestTensorOps(unittest.TestCase):
     def test_add_variable(self):
         shape = (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
-            variable = fixture.create_variable(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
+            variable = fixture.create_variable(shape, dtype='int32')
             tensor2 = tensor1 + variable
             tensor3 = variable + tensor1
 
@@ -138,7 +138,7 @@ class TestTensorOps(unittest.TestCase):
     def test_neg(self):
         shape = (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
             tensor2 = -tensor1
 
         session = nn.Session()
@@ -150,7 +150,7 @@ class TestTensorOps(unittest.TestCase):
     def test_sub_numbers(self):
         constant, shape = 10, (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
             tensor2 = tensor1 - constant
             tensor3 = constant - tensor1
 
@@ -165,7 +165,7 @@ class TestTensorOps(unittest.TestCase):
     def test_sub_tensor(self):
         shape = (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
             tensor2 = tensor1 * tensor1
 
         session = nn.Session()
@@ -179,7 +179,7 @@ class TestTensorOps(unittest.TestCase):
         shape = (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
             input_ = nn.Input(shape=shape, dtype='int32')
-            tensor1 = fixture.create_tensor(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
             tensor2 = tensor1 - input_
             tensor3 = input_ - tensor1
 
@@ -195,8 +195,8 @@ class TestTensorOps(unittest.TestCase):
     def test_sub_variable(self):
         shape = (3, 5)
         with nn.variable_scope(self.id().replace('.', '/')):
-            tensor1 = fixture.create_tensor(shape)
-            variable = fixture.create_variable(shape)
+            tensor1 = fixture.create_tensor(shape, dtype='int32')
+            variable = fixture.create_variable(shape, dtype='int32')
             tensor2 = tensor1 - variable
             tensor3 = variable - tensor1
 


### PR DESCRIPTION
In theano 0.9, applying mean to 'int32' cannot be optimized as it tries to replace with 'int64' tensor.

So far 'mean' is not intended to be used over integer type, so we change dtype for test.