### PR TITLE
Register gradients

### DIFF
--- a/luchador/nn/base/optimizer.py
+++ b/luchador/nn/base/optimizer.py
@@ -96,6 +96,8 @@ class BaseOptimizer(luchador.util.SerializeMixin):
         Operation
             Operation which updates parameter variables
         """
+        grads_and_vars = [
+            (grad.unwrap(), var.unwrap()) for grad, var in grads_and_vars]
         return self._apply_gradients(grads_and_vars, **kwargs)
 
     @abc.abstractmethod

--- a/luchador/nn/tensorflow/optimizer.py
+++ b/luchador/nn/tensorflow/optimizer.py
@@ -52,7 +52,7 @@ class OptimizerMixin(object):  # pylint: disable=too-few-public-methods
         kws1, kws2 = _parse_kwargs(kwargs)
         grads_and_vars = self.compute_gradients(loss, wrt=wrt, **kws1)
         grads_and_vars_ = [g_v for g_v in grads_and_vars if g_v[0] is not None]
-        return self._apply_gradients(grads_and_vars_, **kws2)
+        return self.apply_gradients(grads_and_vars_, **kws2)
 
     def _compute_gradients(self, loss, wrt, **kwargs):
         """Compute gradient
@@ -80,10 +80,20 @@ class OptimizerMixin(object):  # pylint: disable=too-few-public-methods
         ret, i = [], 0
         for var in wrt:
             if var.trainable:
-                ret.append(grads_and_vars[i])
+                # Gradient Tensor is registered using
+                # `<scope>/<variable_name>_grad` name pattern,
+                # so that when same variable is used to compute gradient for
+                # different loss. This way, the resulting gradients are
+                # retrievable, given that gradients were computed in
+                # different scope.
+                scope_ = scope.get_variable_scope().name
+                name = '{}/{}_grad'.format(scope_, var.name)
+                tensor = wrapper.Tensor(
+                    grads_and_vars[i][0], name=name)
                 i += 1
             else:
-                ret.append((None, var.unwrap()))
+                tensor = None
+            ret.append((tensor, var))
         return ret
 
     def _apply_gradients(self, grads_and_vars, **kwargs):

--- a/luchador/nn/tensorflow/optimizer.py
+++ b/luchador/nn/tensorflow/optimizer.py
@@ -102,15 +102,19 @@ class OptimizerMixin(object):  # pylint: disable=too-few-public-methods
         This also store slot variables of TF native Optimizers to luchador
         Optimizer.
 
-        Args:
-          grads_and_vars (list of Tensor pairs): Value returned by
-                                                 compute_gradient method.
+        Parameters
+        ----------
+        grads_and_vars : list of tensorflow Tensor pairs
+            Value returned by compute_gradient method.
 
-          **kwargs: Other arguments passed to apply_gradients of
-                    underlying Tenasorflow native Optimizer.
+        **kwargs :
+            Other arguments passed to apply_gradients of underlying
+            Tenasorflow native Optimizer.
 
-        Returns:
-          Operation: Operation which updates parmeter variables.
+        Returns
+        -------
+        Operation
+            Operation which updates parmeter variables.
         """
         minimize_op = self.optimizer.apply_gradients(grads_and_vars, **kwargs)
         self._register_slot(grads_and_vars)

--- a/tests/unit/nn/optimizer_test.py
+++ b/tests/unit/nn/optimizer_test.py
@@ -40,36 +40,53 @@ class OptimizerGradientTest(fixture.TestCase):
     """Test gradient computation interface IO"""
     def test_compute_gradients_with_trainables(self):
         """compute_gradients computes gradients for trainable wrt"""
+        sgd = nn.optimizer.SGD(learning_rate=0.01)
         with nn.variable_scope(self.get_scope()):
             xs = [nn.get_variable(
                 name='x_{}'.format(i), shape=(), trainable=True,
             ) for i in range(3)]
             y = xs[0] + xs[1] + xs[2]
-
-        sgd = nn.optimizer.SGD(learning_rate=0.01)
-        grads_and_vars = sgd.compute_gradients(y, wrt=xs)
+            grads_and_vars = sgd.compute_gradients(y, wrt=xs)
         self.assertEqual(len(xs), len(grads_and_vars))
         for i, (grad, var) in enumerate(grads_and_vars):
-            self.assertIs(xs[i].unwrap(), var)
+            self.assertIs(xs[i], var)
             self.assertIsNotNone(grad)
 
     def test_compute_gradients(self):
         """compute_gradients returns None for non-trainable wrt"""
+        sgd = nn.optimizer.SGD(learning_rate=0.01)
         with nn.variable_scope(self.get_scope()):
             xs = [nn.get_variable(
                 name='x_{}'.format(i), shape=(), trainable=bool(i % 2),
             ) for i in range(5)]
             y = xs[0] + xs[1] + xs[2] + xs[3] + xs[4]
-
-        sgd = nn.optimizer.SGD(learning_rate=0.01)
-        grads_and_vars = sgd.compute_gradients(y, wrt=xs)
+            grads_and_vars = sgd.compute_gradients(y, wrt=xs)
         self.assertEqual(len(xs), len(grads_and_vars))
         for i, (grad, var) in enumerate(grads_and_vars):
-            self.assertIs(xs[i].unwrap(), var)
+            self.assertIs(xs[i], var)
             if i % 2:
                 self.assertIsNotNone(grad)
             else:
                 self.assertIsNone(grad)
+
+    def test_get_gradients(self):
+        """gradients can be retrieved with get_tensor"""
+        sgd = nn.optimizer.SGD(learning_rate=0.01)
+        scope = self.get_scope()
+        with nn.variable_scope(scope):
+            xs = [nn.get_variable(
+                name='x_{}'.format(i), shape=(), trainable=True,
+            ) for i in range(5)]
+            y = xs[0] + xs[1] + xs[2] + xs[3] + xs[4]
+            grads_and_vars = sgd.compute_gradients(y, wrt=xs)
+
+            for i in range(5):
+                grad = nn.get_tensor('{}_grad'.format(xs[i].name))
+                self.assertIs(grads_and_vars[i][0], grad)
+
+        for i in range(5):
+            grad = nn.get_tensor('{}/{}_grad'.format(scope, xs[i].name))
+            self.assertIs(grads_and_vars[i][0], grad)
 
 
 class AdamTest(fixture.TestCase):


### PR DESCRIPTION
When creating optimization operation with Optimizers, resulting gradient Tensors are registered to global list so that `get_tensor` can retrieve gradients later.