### PR TITLE
Prefix name with scope at wrapper creation time

### DIFF
--- a/luchador/nn/tensorflow/optimizer.py
+++ b/luchador/nn/tensorflow/optimizer.py
@@ -80,8 +80,8 @@ class OptimizerMixin(object):  # pylint: disable=too-few-public-methods
         ret, i = [], 0
         for var in wrt:
             if var.trainable:
-                tensor = wrapper.Tensor(
-                    grads_and_vars[i][0], name='{}_grad'.format(var.name))
+                name_ = '{}_grad'.format(var.name)
+                tensor = wrapper.Tensor(grads_and_vars[i][0], name=name_)
                 i += 1
             else:
                 tensor = None

--- a/luchador/nn/tensorflow/optimizer.py
+++ b/luchador/nn/tensorflow/optimizer.py
@@ -80,16 +80,8 @@ class OptimizerMixin(object):  # pylint: disable=too-few-public-methods
         ret, i = [], 0
         for var in wrt:
             if var.trainable:
-                # Gradient Tensor is registered using
-                # `<scope>/<variable_name>_grad` name pattern,
-                # so that when same variable is used to compute gradient for
-                # different loss. This way, the resulting gradients are
-                # retrievable, given that gradients were computed in
-                # different scope.
-                scope_ = scope.get_variable_scope().name
-                name = '{}/{}_grad'.format(scope_, var.name)
                 tensor = wrapper.Tensor(
-                    grads_and_vars[i][0], name=name)
+                    grads_and_vars[i][0], name='{}_grad'.format(var.name))
                 i += 1
             else:
                 tensor = None
@@ -260,9 +252,6 @@ class Adam(OptimizerMixin, base_optimizer.BaseAdam):
         ret = super(Adam, self)._apply_gradients(grads_and_vars, **kwargs)
         name1 = '{}/{}'.format(self.args['name'], 'beta1_power')
         name2 = '{}/{}'.format(self.args['name'], 'beta2_power')
-        scope_ = scope.get_variable_scope().name
-        name1 = '{}/{}'.format(scope_, name1) if scope_ else name1
-        name2 = '{}/{}'.format(scope_, name2) if scope_ else name2
         self.slot.extend([
             wrapper.Variable(self.optimizer._beta1_power, name=name1),
             wrapper.Variable(self.optimizer._beta2_power, name=name2),

--- a/luchador/nn/theano/optimizer.py
+++ b/luchador/nn/theano/optimizer.py
@@ -59,16 +59,8 @@ class OptimizerMixin(object):  # pylint: disable=too-few-public-methods
         ret, i = [], 0
         for var in wrt:
             if var.trainable:
-                # Gradient Tensor is registered using
-                # `<scope>/<variable_name>_grad` name pattern,
-                # so that when same variable is used to compute gradient for
-                # different loss. This way, the resulting gradients are
-                # retrievable, given that gradients were computed in
-                # different scope.
-                scope_ = scope.get_variable_scope().name
-                name = '{}/{}_grad'.format(scope_, var.name)
-                tensor = wrapper.Tensor(
-                    grads[i], shape=var.shape, name=name)
+                name_ = '{}_grad'.format(var.name)
+                tensor = wrapper.Tensor(grads[i], shape=var.shape, name=name_)
                 i += 1
             else:
                 tensor = None

--- a/luchador/nn/theano/scope.py
+++ b/luchador/nn/theano/scope.py
@@ -120,15 +120,15 @@ def get_variable(
 
     # 1. Check the current variable scope
     scope = wrapper.get_scope_()
-    name = '{}/{}'.format(scope, name) if scope else name
+    name_ = '{}/{}'.format(scope, name) if scope else name
 
-    var = base_wrapper.retrieve_variable(name)
+    var = base_wrapper.retrieve_variable(name_)
     if wrapper.get_flag_():  # Search for an existing variable
         if var is None:
             raise ValueError(
                 'Variable {} does not exist, disallowed. '
                 'Did you mean to set reuse=None in VarScope?'
-                .format(name)
+                .format(name_)
             )
         return var
     else:  # Create new variable
@@ -136,12 +136,12 @@ def get_variable(
             raise ValueError(
                 'Variable {} already exists, disallowed. '
                 'Did you mean to set reuse=True in VarScope?'
-                .format(name)
+                .format(name_)
             )
         if shape is None:
             raise ValueError(
                 'Shape of a new variable ({}) must be fully defined, '
-                'but instead was {}.'.format(name, shape))
+                'but instead was {}.'.format(name_, shape))
 
         if not initializer:
             initializer = Normal(dtype=dtype)
@@ -153,6 +153,6 @@ def get_variable(
         return wrapper.Variable(
             theano.shared(
                 value=np.array(initializer.sample(shape), dtype=dtype),
-                name=name, allow_downcast=True, **kwargs
-            ), trainable=trainable,
+                name=name_, allow_downcast=True, **kwargs
+            ), trainable=trainable, name=name,
         )

--- a/luchador/nn/theano/scope.py
+++ b/luchador/nn/theano/scope.py
@@ -46,24 +46,26 @@ class VariableScope(object):
     @staticmethod
     def reuse_variables():
         """Set reuse flag to True"""
-        wrapper._set_flag(True)
+        wrapper.set_flag_(True)
 
     def _open(self):
-        self.previous_scopes.append(wrapper._get_scope())
-        self.previous_reuse_flags.append(wrapper._get_flag())
-        wrapper._set_scope(self.name)
-        wrapper._set_flag(self.reuse)
+        self.previous_scopes.append(wrapper.get_scope_())
+        self.previous_reuse_flags.append(wrapper.get_flag_())
+        wrapper.set_scope_(self.name)
+        wrapper.set_flag_(self.reuse)
 
     def _close(self):
-        wrapper._set_scope(self.previous_scopes.pop())
-        wrapper._set_flag(self.previous_reuse_flags.pop())
+        wrapper.set_scope_(self.previous_scopes.pop())
+        wrapper.set_flag_(self.previous_reuse_flags.pop())
 
     def __enter__(self):
+        # pylint: disable=protected-access
         self._open()
         _LG.debug('Current Scope: %s', wrapper._CURRENT_VARIABLE_SCOPE)
         return self
 
     def __exit__(self, type_, value, traceback):
+        # pylint: disable=protected-access
         self._close()
         _LG.debug('Current Scope: %s', wrapper._CURRENT_VARIABLE_SCOPE)
 
@@ -76,15 +78,15 @@ def variable_scope(name_or_scope, reuse=None):
         return name_or_scope
 
     scope = (
-        '{}/{}'.format(wrapper._get_scope(), name_or_scope)
-        if wrapper._get_scope() else name_or_scope
+        '{}/{}'.format(wrapper.get_scope_(), name_or_scope)
+        if wrapper.get_scope_() else name_or_scope
     )
     return VariableScope(reuse, scope)
 
 
 def get_variable_scope():
     """Return the current variable scope"""
-    return VariableScope(wrapper._get_flag(), wrapper._get_scope())
+    return VariableScope(wrapper.get_flag_(), wrapper.get_scope_())
 
 
 def get_tensor(name):
@@ -99,7 +101,7 @@ def get_tensor(name):
     Tensor
     """
     try:
-        scope = wrapper._get_scope()
+        scope = wrapper.get_scope_()
         return base_wrapper.retrieve_tensor('{}/{}'.format(scope, name))
     except ValueError:
         pass
@@ -117,11 +119,11 @@ def get_variable(
         warnings.warn('`regularizer` is not implemented in Theano backend.')
 
     # 1. Check the current variable scope
-    scope = wrapper._get_scope()
+    scope = wrapper.get_scope_()
     name = '{}/{}'.format(scope, name) if scope else name
 
     var = base_wrapper.retrieve_variable(name)
-    if wrapper._get_flag():  # Search for an existing variable
+    if wrapper.get_flag_():  # Search for an existing variable
         if var is None:
             raise ValueError(
                 'Variable {} does not exist, disallowed. '

--- a/luchador/nn/theano/wrapper.py
+++ b/luchador/nn/theano/wrapper.py
@@ -13,6 +13,38 @@ from luchador.nn.base.wrapper import Operation
 __all__ = ['Variable', 'Tensor', 'Input', 'Operation']
 
 
+###############################################################################
+_CURRENT_REUSE_FLAG = False
+_CURRENT_VARIABLE_SCOPE = ''
+
+
+def _set_flag(flag):
+    # pylint: disable=global-statement
+    global _CURRENT_REUSE_FLAG
+    _CURRENT_REUSE_FLAG = flag
+
+
+def _set_scope(scope):
+    # pylint: disable=global-statement
+    global _CURRENT_VARIABLE_SCOPE
+    _CURRENT_VARIABLE_SCOPE = scope
+
+
+def _get_flag():
+    return _CURRENT_REUSE_FLAG
+
+
+def _get_scope():
+    return _CURRENT_VARIABLE_SCOPE
+
+
+def _reset():
+    """Reset variable scope and remove cached variables. For Testing"""
+    _set_flag(False)
+    _set_scope('')
+
+
+###############################################################################
 def _is_same_shape(shape1, shape2):
     if not len(shape1) == len(shape2):
         return False

--- a/luchador/nn/theano/wrapper.py
+++ b/luchador/nn/theano/wrapper.py
@@ -18,30 +18,34 @@ _CURRENT_REUSE_FLAG = False
 _CURRENT_VARIABLE_SCOPE = ''
 
 
-def _set_flag(flag):
+def set_flag_(flag):
+    """Set reuse flag. Internal user only"""
     # pylint: disable=global-statement
     global _CURRENT_REUSE_FLAG
     _CURRENT_REUSE_FLAG = flag
 
 
-def _set_scope(scope):
+def set_scope_(scope):
+    """Set scope value. Internal user only"""
     # pylint: disable=global-statement
     global _CURRENT_VARIABLE_SCOPE
     _CURRENT_VARIABLE_SCOPE = scope
 
 
-def _get_flag():
+def get_flag_():
+    """Get reuse flag. Internal user only"""
     return _CURRENT_REUSE_FLAG
 
 
-def _get_scope():
+def get_scope_():
+    """Get scope value. Internal user only"""
     return _CURRENT_VARIABLE_SCOPE
 
 
 def _reset():
     """Reset variable scope and remove cached variables. For Testing"""
-    _set_flag(False)
-    _set_scope('')
+    set_flag_(False)
+    set_scope_('')
 
 
 ###############################################################################

--- a/luchador/nn/theano/wrapper.py
+++ b/luchador/nn/theano/wrapper.py
@@ -305,6 +305,11 @@ class TensorMixin(object):  # pylint: disable=too-few-public-methods
         return Tensor(tensor=_tensor, shape=_shape, name=name)
 
 
+def _prefix_with_scope(name):
+    scope_ = get_scope_()
+    return '{}/{}'.format(scope_, name) if scope_ else name
+
+
 class Variable(TensorMixin, base_wrapper.BaseVariable):
     """Wrap SharedVariable object for storing network parameters"""
     def __init__(self, variable, name=None, trainable=True):
@@ -316,7 +321,7 @@ class Variable(TensorMixin, base_wrapper.BaseVariable):
             overwritten with this name, otherwise, name is constructed in the
             manner as Tensorflow.
         """
-        name = name or variable.name
+        name = _prefix_with_scope(name or variable.name)
         val = variable.get_value()
         super(Variable, self).__init__(
             tensor=variable, shape=val.shape, name=name,
@@ -335,6 +340,7 @@ class Tensor(TensorMixin, base_wrapper.BaseTensor):
         """
         if -1 in shape:
             shape = [None if val < 0 else val for val in shape]
+        name = _prefix_with_scope(name) if name else None
         super(Tensor, self).__init__(
             tensor=tensor, shape=shape, name=name, dtype=tensor.dtype)
 
@@ -365,6 +371,7 @@ class Input(TensorMixin, base_wrapper.BaseWrapper):
           name (str): The name of the resulting object.
           dtype (NumPy dtype or None): If None, default dtype(floatX) is used
         """
+        name = _prefix_with_scope(name) if name else None
         tensor = _create_placeholder(dtype, len(shape), name)
         super(Input, self).__init__(
             tensor=tensor, shape=shape, name=name, dtype=tensor.dtype)

--- a/tests/unit/fixture.py
+++ b/tests/unit/fixture.py
@@ -83,9 +83,6 @@ def create_ones_tensor(shape, dtype, name='ones_tensor'):
         import theano.tensor as be
     else:
         import tensorflow as be
-    scope = nn.get_variable_scope().name
-    if scope:
-        name = '{}/{}'.format(scope, name)
     tensor = be.ones(shape, dtype=dtype)
     return nn.Tensor(tensor, shape=shape, name=name)
 

--- a/tests/unit/nn/theano/layer_test.py
+++ b/tests/unit/nn/theano/layer_test.py
@@ -26,7 +26,7 @@ class TestConv2D(TestCase):
     longMessage = True
 
     def setUp(self):
-        be.scope._reset()
+        be.wrapper._reset()
 
     def test_map_border_mode(self):
         """padding string is correctly mapped to border_mode"""

--- a/tests/unit/nn/theano/scope_test.py
+++ b/tests/unit/nn/theano/scope_test.py
@@ -18,22 +18,22 @@ class _ScopeTestCase(TestCase):
 
     def tearDown(self):
         # After each test, scope should be reset to root
-        expected, found = '', be.scope._get_scope()
+        expected, found = '', be.wrapper._get_scope()
         # Sanitize global scope for the next test in case something went wrong
-        be.scope._reset()
+        be.wrapper._reset()
         self.assertEqual(
             expected, found,
             'Variable scope was not properly closed in the last test. ')
 
     def _check_scope(self, expected, found=None):
-        found = found or be.scope._get_scope()
+        found = found or be.wrapper._get_scope()
         self.assertEqual(
             expected, found,
             'Failed to update current variable scope. '
         )
 
     def _check_reuse(self, expected, found=None):
-        found = found or be.scope._get_flag()
+        found = found or be.wrapper._get_flag()
         self.assertEqual(
             expected, found,
             'Failed to update current reuse flag. '
@@ -90,8 +90,8 @@ class TestVariableScopeClass(_ScopeTestCase):
         """VariableScope revert current variable scope after close"""
         scopes = [self.get_scope(scope) for scope in ['aaa', 'bbb', 'ccc']]
         for scope in scopes:
-            expected_scope = be.scope._get_scope()
-            expected_reuse = be.scope._get_flag()
+            expected_scope = be.wrapper._get_scope()
+            expected_reuse = be.wrapper._get_flag()
             with be.scope.VariableScope(False, scope):
                 pass
             self._check_scope(expected_scope)
@@ -188,7 +188,7 @@ class TestGetVariable(_ScopeTestCase):
         """get_variable create variable"""
         scope = self.get_scope()
         var1 = be.scope.get_variable(scope, shape=[3, 1])
-        be.scope._set_flag(True)
+        be.wrapper._set_flag(True)
         var2 = be.scope.get_variable(scope)
         self.assertIs(
             var1.unwrap(), var2.unwrap(),
@@ -197,7 +197,7 @@ class TestGetVariable(_ScopeTestCase):
 
     def test_get_variable_raises_when_reuseing_non_existent_variable(self):
         """get_variable raise when trying to reuse non existent variable"""
-        be.scope._set_flag(True)
+        be.wrapper._set_flag(True)
         try:
             be.scope.get_variable('non_existing_variable_name')
         except ValueError:

--- a/tests/unit/nn/theano/scope_test.py
+++ b/tests/unit/nn/theano/scope_test.py
@@ -18,7 +18,7 @@ class _ScopeTestCase(TestCase):
 
     def tearDown(self):
         # After each test, scope should be reset to root
-        expected, found = '', be.wrapper._get_scope()
+        expected, found = '', be.wrapper.get_scope_()
         # Sanitize global scope for the next test in case something went wrong
         be.wrapper._reset()
         self.assertEqual(
@@ -26,14 +26,14 @@ class _ScopeTestCase(TestCase):
             'Variable scope was not properly closed in the last test. ')
 
     def _check_scope(self, expected, found=None):
-        found = found or be.wrapper._get_scope()
+        found = found or be.wrapper.get_scope_()
         self.assertEqual(
             expected, found,
             'Failed to update current variable scope. '
         )
 
     def _check_reuse(self, expected, found=None):
-        found = found or be.wrapper._get_flag()
+        found = found or be.wrapper.get_flag_()
         self.assertEqual(
             expected, found,
             'Failed to update current reuse flag. '
@@ -90,8 +90,8 @@ class TestVariableScopeClass(_ScopeTestCase):
         """VariableScope revert current variable scope after close"""
         scopes = [self.get_scope(scope) for scope in ['aaa', 'bbb', 'ccc']]
         for scope in scopes:
-            expected_scope = be.wrapper._get_scope()
-            expected_reuse = be.wrapper._get_flag()
+            expected_scope = be.wrapper.get_scope_()
+            expected_reuse = be.wrapper.get_flag_()
             with be.scope.VariableScope(False, scope):
                 pass
             self._check_scope(expected_scope)
@@ -188,7 +188,7 @@ class TestGetVariable(_ScopeTestCase):
         """get_variable create variable"""
         scope = self.get_scope()
         var1 = be.scope.get_variable(scope, shape=[3, 1])
-        be.wrapper._set_flag(True)
+        be.wrapper.set_flag_(True)
         var2 = be.scope.get_variable(scope)
         self.assertIs(
             var1.unwrap(), var2.unwrap(),
@@ -197,7 +197,7 @@ class TestGetVariable(_ScopeTestCase):
 
     def test_get_variable_raises_when_reuseing_non_existent_variable(self):
         """get_variable raise when trying to reuse non existent variable"""
-        be.wrapper._set_flag(True)
+        be.wrapper.set_flag_(True)
         try:
             be.scope.get_variable('non_existing_variable_name')
         except ValueError:


### PR DESCRIPTION
Given the fact that `get_variable(name)` automatically prefix variable name with scope,
it is more consistent to make the name of all wrappers (`Tensor`, `Variable` and `Input`) prefixed with scope at creation time.