### PR TITLE
Refactor Layer internal

### DIFF
--- a/luchador/nn/base/initializer.py
+++ b/luchador/nn/base/initializer.py
@@ -9,7 +9,7 @@ import luchador.util
 _LG = logging.getLogger(__name__)
 
 
-class BaseInitializer(luchador.util.SerializeMixin, object):
+class BaseInitializer(luchador.util.StoreMixin, object):
     """Define Common interface for Initializer classes"""
     __metaclass__ = abc.ABCMeta
 

--- a/luchador/nn/base/layer.py
+++ b/luchador/nn/base/layer.py
@@ -19,14 +19,11 @@ class BaseLayer(luchador.util.StoreMixin, object):
         super(BaseLayer, self).__init__()
         self._store_args(**kwargs)
 
-        self.update_operations = OrderedDict()
+        self._update_operation = None
         self._parameter_variables = OrderedDict()
 
     ###########################################################################
-    # Setter for learnable parameters
-    def _add_update(self, name, operation):
-        self.update_operations[name] = operation
-
+    # Getter for learnable parameters
     def get_parameter_variables(self, name=None):
         """Get parameter variables
 
@@ -54,17 +51,10 @@ class BaseLayer(luchador.util.StoreMixin, object):
 
         Currently only BatchNormalization requires such operation.
         """
-        return self._get_update_operation()
-
-    @abc.abstractmethod
-    def _get_update_operation(self):
-        raise NotImplementedError(
-            '`get_update_operation` method is not implemented for {}'
-            .format(self.__class__)
-        )
+        return self._update_operation
 
     ###########################################################################
-    # Setter/Getter for learnable parameters
+    # Setter for learnable parameters
     def _add_parameter(self, name, variable):
         self._parameter_variables[name] = variable
 

--- a/luchador/nn/base/layer.py
+++ b/luchador/nn/base/layer.py
@@ -11,7 +11,7 @@ import luchador.util
 _LG = logging.getLogger(__name__)
 
 
-class BaseLayer(luchador.util.SerializeMixin, object):
+class BaseLayer(luchador.util.StoreMixin, object):
     """Define common interface (``build``, ``parameters`` ...) of Layer"""
     __metaclass__ = abc.ABCMeta
 
@@ -41,6 +41,8 @@ class BaseLayer(luchador.util.SerializeMixin, object):
         list
             List of Variable instances consisting this layer
         """
+        if name:
+            return self._parameter_variables[name]
         return self._parameter_variables.values()
 
     def get_update_operation(self):

--- a/luchador/nn/base/layer.py
+++ b/luchador/nn/base/layer.py
@@ -45,13 +45,19 @@ class BaseLayer(luchador.util.StoreMixin, object):
         return self._parameter_variables.values()
 
     def get_update_operation(self):
-        """Get operation which updates Layer parameter
+        """Get Operation which updates Layer parameter
 
         For layers which require updates other than back propagate
         optimization, Operation returned by this function must be
         fed to Session.run function.
 
         Currently only BatchNormalization requires such operation.
+
+        Returns
+        -------
+        Operation or None
+            If update Operation is defined (BatchNormalization), Operation is
+            returned, else None
         """
         return self._update_operation
 

--- a/luchador/nn/base/layer.py
+++ b/luchador/nn/base/layer.py
@@ -20,12 +20,28 @@ class BaseLayer(luchador.util.SerializeMixin, object):
         self._store_args(**kwargs)
 
         self.update_operations = OrderedDict()
-        self.parameter_variables = OrderedDict()
+        self._parameter_variables = OrderedDict()
 
     ###########################################################################
     # Setter for learnable parameters
     def _add_update(self, name, operation):
         self.update_operations[name] = operation
+
+    def get_parameter_variables(self, name=None):
+        """Get parameter variables
+
+        Parameters
+        ----------
+        name : str or None
+            The name of parameter such as `weight` or `var` to retrieve.
+            If not given, all parameter Variable objects are returned.
+
+        Returns
+        -------
+        list
+            List of Variable instances consisting this layer
+        """
+        return self._parameter_variables.values()
 
     def get_update_operation(self):
         """Get operation which updates Layer parameter
@@ -48,10 +64,10 @@ class BaseLayer(luchador.util.SerializeMixin, object):
     ###########################################################################
     # Setter/Getter for learnable parameters
     def _add_parameter(self, name, variable):
-        self.parameter_variables[name] = variable
+        self._parameter_variables[name] = variable
 
     def _get_parameter(self, name):
-        return self.parameter_variables[name]
+        return self._parameter_variables[name]
 
     ###########################################################################
     # Functions for building computation graph

--- a/luchador/nn/base/layer.py
+++ b/luchador/nn/base/layer.py
@@ -30,13 +30,15 @@ class BaseLayer(luchador.util.StoreMixin, object):
         Parameters
         ----------
         name : str or None
-            The name of parameter such as `weight` or `var` to retrieve.
-            If not given, all parameter Variable objects are returned.
+            The name of the parameter (such as ``weight``) to retrieve.
+            If not given, all parameter Variables consisting this layer are
+            returned.
 
         Returns
         -------
-        list
-            List of Variable instances consisting this layer
+        [list of] Variable
+            When name is given, a single Variable is returned, otherwise
+            list of Variables are returned.
         """
         if name:
             return self._parameter_variables[name]
@@ -113,6 +115,11 @@ class BaseDense(BaseLayer):
 
     with_bias : bool
         When True, bias term is added after multiplication.
+
+    Notes
+    -----
+    To fetch paramter variables with :any:`get_variable`, use keys
+    ``weight`` and ``bias`` in the same scope as layer build.
     """
     def __init__(self, n_nodes, initializers=None, with_bias=True):
         super(BaseDense, self).__init__(
@@ -136,7 +143,6 @@ class BaseConv2D(BaseLayer):
         NHWC format : (Tensorflow backend only)
             (batch size, output height, output width, **#output channels**)
 
-
     Parameters
     ----------
     filter_height : int
@@ -157,7 +163,7 @@ class BaseConv2D(BaseLayer):
             The output is subsapmled by ``strides[0]`` in height and
             ``striders[1]`` in width.
 
-        Note
+        Notes
             [Tensorflow only]
 
             When given type is tuple of four int, their order must be
@@ -177,6 +183,11 @@ class BaseConv2D(BaseLayer):
     kwargs
         use_cudnn_on_gpu
             [Tensorflow only] : Arguments passed to ``tf.nn.conv2d``
+
+    Notes
+    -----
+    To fetch paramter variables with :any:`get_variable`, use keys
+    ``weight`` and ``bias`` in the same scope as layer build.
     """
     def __init__(self, filter_height, filter_width, n_filters, strides,
                  padding='VALID', initializers=None, with_bias=True, **kwargs):
@@ -297,6 +308,14 @@ class BaseBatchNormalization(BaseLayer):
 
     .. math::
         y = \\frac{x - \\mu}{\\sqrt{\\sigma^2 + \\epsilon}} \\gamma + \\beta
+
+    Notes
+    -----
+    To fetch paramter variables with :any:`get_variable`, use keys ``mean``,
+    ``var``, ``scale`` and ``offset`` in the same scope as layer build.
+
+    To fetch update operation with :any:`get_operation` use key ``bn_update``
+    in the same scope as layer build.
 
     References
     ----------

--- a/luchador/nn/base/optimizer.py
+++ b/luchador/nn/base/optimizer.py
@@ -6,7 +6,7 @@ import abc
 import luchador.util
 
 
-class BaseOptimizer(luchador.util.SerializeMixin):
+class BaseOptimizer(luchador.util.StoreMixin):
     """Define common interface of Optimizer"""
     __metaclass__ = abc.ABCMeta
 

--- a/luchador/nn/model/sequential.py
+++ b/luchador/nn/model/sequential.py
@@ -174,7 +174,12 @@ class Sequential(BaseModel):
         list
             List of update operations from each layer
         """
-        return [cfg.layer.get_update_operation() for cfg in self.layer_configs]
+        ret = []
+        for cfg in self.layer_configs:
+            update = cfg.layer.get_update_operation()
+            if update:
+                ret.append(update)
+        return ret
 
     ###########################################################################
     def __repr__(self):

--- a/luchador/nn/model/sequential.py
+++ b/luchador/nn/model/sequential.py
@@ -153,7 +153,7 @@ class Sequential(BaseModel):
         """
         ret = []
         for cfg in self.layer_configs:
-            ret.extend(cfg.layer.parameter_variables.values())
+            ret.extend(cfg.layer.get_parameter_variables())
         return ret
 
     def get_output_tensors(self):

--- a/luchador/nn/tensorflow/layer.py
+++ b/luchador/nn/tensorflow/layer.py
@@ -83,7 +83,7 @@ class Dense(LayerMixin, base_layer.BaseDense):
             self._add_parameter('bias', bias)
 
     def _build(self, input_tensor):
-        if not self.parameter_variables:
+        if not self._parameter_variables:
             self._instantiate_parameters(
                 input_tensor.shape[1], input_tensor.dtype)
 
@@ -214,7 +214,7 @@ class Conv2D(LayerMixin, base_layer.BaseConv2D):
             self._add_parameter('bias', bias)
 
     def _build(self, input_tensor):
-        if not self.parameter_variables:
+        if not self._parameter_variables:
             self._instantiate_parameters(
                 input_tensor.shape, input_tensor.dtype)
 
@@ -435,7 +435,7 @@ class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
 
     def _build(self, input_tensor):
         input_shape = input_tensor.shape
-        if not self.parameter_variables:
+        if not self._parameter_variables:
             self._instantiate_parameters(input_shape)
 
         input_ = input_tensor.unwrap()

--- a/luchador/nn/tensorflow/layer.py
+++ b/luchador/nn/tensorflow/layer.py
@@ -17,7 +17,6 @@ from . import scope, wrapper, initializer
 # pylint: disable=too-few-public-methods, invalid-name
 
 __all__ = [
-    'LayerMixin',
     'Dense', 'Conv2D',
     'ReLU', 'Softplus',
     'Sigmoid', 'Softmax',
@@ -29,16 +28,6 @@ __all__ = [
 ]
 
 _LG = logging.getLogger(__name__)
-
-
-class LayerMixin(object):
-    """Implement the following common Layer methods in Tensorflow
-
-    - ``_get_update_operation``
-
-    """
-    def _get_update_operation(self):
-        return wrapper.Operation(tf.group(*self.update_operations.values()))
 
 
 def _get_initializers(cfg, with_bias):
@@ -60,7 +49,7 @@ def _get_initializers(cfg, with_bias):
     return ret
 
 
-class Dense(LayerMixin, base_layer.BaseDense):
+class Dense(base_layer.BaseDense):
     """Implement Dense layer in Tensorflow.
 
     See :any:`BaseDense` for detail.
@@ -135,7 +124,7 @@ def _validate_strides(strides):
     )
 
 
-class Conv2D(LayerMixin, base_layer.BaseConv2D):
+class Conv2D(base_layer.BaseConv2D):
     """Implement Conv2D layer in Tensorflow.
 
     See :any:`BaseConv2D` for detail.
@@ -236,7 +225,7 @@ class Conv2D(LayerMixin, base_layer.BaseConv2D):
         return wrapper.Tensor(output, name='output')
 
 
-class ReLU(LayerMixin, base_layer.BaseReLU):
+class ReLU(base_layer.BaseReLU):
     """Implement ReLU in Tensorflow.
 
     See :any:`BaseReLU` for detail.
@@ -246,7 +235,7 @@ class ReLU(LayerMixin, base_layer.BaseReLU):
         return wrapper.Tensor(output, name='output')
 
 
-class Sigmoid(LayerMixin, base_layer.BaseSigmoid):
+class Sigmoid(base_layer.BaseSigmoid):
     """Implement Sigmoid in Tensorflow.
 
     See :any:`BaseSigmoid` for detail.
@@ -256,7 +245,7 @@ class Sigmoid(LayerMixin, base_layer.BaseSigmoid):
         return wrapper.Tensor(output, name='output')
 
 
-class Tanh(LayerMixin, base_layer.BaseTanh):
+class Tanh(base_layer.BaseTanh):
     """Implement Tanh in Tensorflow.
 
     See :any:`BaseTanh` for detail.
@@ -266,7 +255,7 @@ class Tanh(LayerMixin, base_layer.BaseTanh):
         return wrapper.Tensor(output, name='output')
 
 
-class Sin(LayerMixin, base_layer.BaseSin):
+class Sin(base_layer.BaseSin):
     """Implement Sin in Tensorflow.
 
     See :any:`BaseSin` for detail.
@@ -276,7 +265,7 @@ class Sin(LayerMixin, base_layer.BaseSin):
         return wrapper.Tensor(output, name='output')
 
 
-class Cos(LayerMixin, base_layer.BaseCos):
+class Cos(base_layer.BaseCos):
     """Implement Cos in Tensorflow.
 
     See :any:`BaseCos` for detail.
@@ -286,7 +275,7 @@ class Cos(LayerMixin, base_layer.BaseCos):
         return wrapper.Tensor(output, name='output')
 
 
-class Softmax(LayerMixin, base_layer.BaseSoftmax):
+class Softmax(base_layer.BaseSoftmax):
     """Implement Softmax in Tensorflow.
 
     See :any:`BaseSoftmax` for detail.
@@ -296,7 +285,7 @@ class Softmax(LayerMixin, base_layer.BaseSoftmax):
         return wrapper.Tensor(output, name='output')
 
 
-class Softplus(LayerMixin, base_layer.BaseSoftplus):
+class Softplus(base_layer.BaseSoftplus):
     """Implement Softplus in Tensorflow.
 
     See :any:`BaseSoftplus` for detail.
@@ -307,7 +296,7 @@ class Softplus(LayerMixin, base_layer.BaseSoftplus):
 
 
 ###############################################################################
-class Flatten(LayerMixin, base_layer.BaseFlatten):
+class Flatten(base_layer.BaseFlatten):
     """Implement Flatten in Tensorflow.
 
     See :any:`BaseFlatten` for detail.
@@ -320,7 +309,7 @@ class Flatten(LayerMixin, base_layer.BaseFlatten):
         return wrapper.Tensor(output, name='output')
 
 
-class Tile(LayerMixin, base_layer.BaseTile):
+class Tile(base_layer.BaseTile):
     """Implement Tile layer in Tensorflow
 
     See :any:`BaseFlatten` for detail.
@@ -330,7 +319,7 @@ class Tile(LayerMixin, base_layer.BaseTile):
 
 
 ###############################################################################
-class Concat(LayerMixin, base_layer.BaseConcat):
+class Concat(base_layer.BaseConcat):
     """Implement Concat in Tensorflow.
 
     See :any:`BaseConcat` for detail.
@@ -341,7 +330,7 @@ class Concat(LayerMixin, base_layer.BaseConcat):
         return wrapper.Tensor(output, name='output')
 
 
-class Add(LayerMixin, base_layer.BaseAdd):
+class Add(base_layer.BaseAdd):
     """Implement Add layer in Tensorflow
 
     See :any: `BaseAdd` for detail.
@@ -356,7 +345,7 @@ class Add(LayerMixin, base_layer.BaseAdd):
         return ret.__add__(var_list[-1], name='output')
 
 
-class Sub(LayerMixin, base_layer.BaseAdd):
+class Sub(base_layer.BaseAdd):
     """Implement Sub layer in Tensorflow
 
     See :any: `BaseSub` for detail.
@@ -369,7 +358,7 @@ class Sub(LayerMixin, base_layer.BaseAdd):
 
 
 ###############################################################################
-class TrueDiv(LayerMixin, base_layer.BaseTrueDiv):
+class TrueDiv(base_layer.BaseTrueDiv):
     """Implement TrueDiv in Tensorflow.
 
     See :any:`BaseTrueDiv` for detail.
@@ -392,7 +381,7 @@ class TrueDiv(LayerMixin, base_layer.BaseTrueDiv):
         return wrapper.Tensor(output, name='output')
 
 
-class Mean(LayerMixin, base_layer.BaseMean):
+class Mean(base_layer.BaseMean):
     """Implement Mean layer in Tensorflow.
 
     See :any:`BaseMean` for detail.
@@ -402,7 +391,7 @@ class Mean(LayerMixin, base_layer.BaseMean):
 
 
 ###############################################################################
-class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
+class BatchNormalization(base_layer.BaseBatchNormalization):
     """Implement BatchNormalization in Tensorflow.
 
     See :any:`BaseBatchNormalization` for detail.
@@ -452,8 +441,13 @@ class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
             new_mean_acc = decay * mean_acc + (1 - decay) * mean_in
             new_var_acc = decay * var_acc + (1 - decay) * var_in
 
-            self._add_update('mean', tf.assign(mean_acc, new_mean_acc))
-            self._add_update('var', tf.assign(var_acc, new_var_acc))
+            self._update_operation = wrapper.Operation(
+                op=[
+                    tf.assign(mean_acc, new_mean_acc),
+                    tf.assign(var_acc, new_var_acc)
+                ],
+                name='bn_update',
+            )
 
             mean_acc = new_mean_acc
             var_acc = new_var_acc
@@ -465,14 +459,14 @@ class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
 
 
 ###############################################################################
-class NHWC2NCHW(LayerMixin, base_layer.BaseNHWC2NCHW):
+class NHWC2NCHW(base_layer.BaseNHWC2NCHW):
     """See :any:`BaseNHWC2NCHW` for detail."""
     def _build(self, input_tensor):
         output = tf.transpose(input_tensor.unwrap(), perm=(0, 3, 1, 2))
         return wrapper.Tensor(output, name='output')
 
 
-class NCHW2NHWC(LayerMixin, base_layer.BaseNCHW2NHWC):
+class NCHW2NHWC(base_layer.BaseNCHW2NHWC):
     """See :any:`BaseNCHW2NHWC` for detail."""
     def _build(self, input_tensor):
         output = tf.transpose(input_tensor.unwrap(), perm=(0, 2, 3, 1))

--- a/luchador/nn/theano/layer.py
+++ b/luchador/nn/theano/layer.py
@@ -83,7 +83,7 @@ class Dense(LayerMixin, base_layer.BaseDense):
             raise ValueError('Input tensor must be 2D. '
                              'Insted of {}'.format(len(input_shape)))
 
-        if not self.parameter_variables:
+        if not self._parameter_variables:
             self._instantiate_parameters(input_shape[1], input_tensor.dtype)
 
         weight = self._get_parameter('weight').unwrap()
@@ -236,7 +236,7 @@ class Conv2D(LayerMixin, base_layer.BaseConv2D):
             raise ValueError('Input tensor must be 4D. '
                              'Insted of {}'.format(len(input_shape)))
 
-        if not self.parameter_variables:
+        if not self._parameter_variables:
             self._instantiate_parameters(input_shape[1], input_tensor.dtype)
 
         filters = self._get_parameter('weight').unwrap()
@@ -491,7 +491,7 @@ class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
         self._add_parameter('offset', offset)
 
     def _build(self, input_tensor):
-        if not self.parameter_variables:
+        if not self._parameter_variables:
             self._instantiate_parameters(
                 input_tensor.shape, input_tensor.dtype)
 

--- a/luchador/nn/theano/layer.py
+++ b/luchador/nn/theano/layer.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import absolute_import
 
 import logging
+from collections import OrderedDict
 
 import theano.tensor as T
 
@@ -13,7 +14,6 @@ from ..base import (
 from . import scope, wrapper, initializer
 
 __all__ = [
-    'LayerMixin',
     'Dense', 'Conv2D',
     'ReLU', 'Softplus',
     'Sigmoid', 'Softmax',
@@ -26,16 +26,6 @@ __all__ = [
 ]
 
 _LG = logging.getLogger(__name__)
-
-
-class LayerMixin(object):  # pylint: disable=too-few-public-methods
-    """Implement the following common Layer methods in Theano
-
-    - ``_get_update_operation``
-
-    """
-    def _get_update_operation(self):
-        return wrapper.Operation(self.update_operations)
 
 
 def _get_initializers(cfg, with_bias):
@@ -56,7 +46,7 @@ def _get_initializers(cfg, with_bias):
     return ret
 
 
-class Dense(LayerMixin, base_layer.BaseDense):
+class Dense(base_layer.BaseDense):
     """Implement Dense layer in Theano.
 
     See :any:`BaseDense` for detail.
@@ -140,7 +130,7 @@ def _validate_strides(strides):
     raise ValueError('`strides` must be either int or tuple of two int')
 
 
-class Conv2D(LayerMixin, base_layer.BaseConv2D):
+class Conv2D(base_layer.BaseConv2D):
     """Implement Conv2D layer in Theano.
 
     See :any:`BaseConv2D` for detail.
@@ -259,7 +249,7 @@ class Conv2D(LayerMixin, base_layer.BaseConv2D):
         return wrapper.Tensor(output_tensor, shape=output_shape, name='output')
 
 
-class ReLU(LayerMixin, base_layer.BaseReLU):
+class ReLU(base_layer.BaseReLU):
     """Implement ReLU layer in Theano.
 
     See :any:`BaseReLU` for detail.
@@ -271,7 +261,7 @@ class ReLU(LayerMixin, base_layer.BaseReLU):
         return wrapper.Tensor(output_tensor, shape=input_shape, name='output')
 
 
-class Sigmoid(LayerMixin, base_layer.BaseSigmoid):
+class Sigmoid(base_layer.BaseSigmoid):
     """Implement Sigmoid layer in Theano.
 
     See :any:`BaseSigmoid` for detail.
@@ -282,7 +272,7 @@ class Sigmoid(LayerMixin, base_layer.BaseSigmoid):
         return wrapper.Tensor(output_tensor, shape=input_shape, name='output')
 
 
-class Tanh(LayerMixin, base_layer.BaseTanh):
+class Tanh(base_layer.BaseTanh):
     """Implement Tanh layer in Theano.
 
     See :any:`BaseTanh` for detail.
@@ -293,7 +283,7 @@ class Tanh(LayerMixin, base_layer.BaseTanh):
         return wrapper.Tensor(output_tensor, shape=input_shape, name='output')
 
 
-class Sin(LayerMixin, base_layer.BaseSin):
+class Sin(base_layer.BaseSin):
     """Implement Sin layer in Theano
 
     See :any:`BaseSin` for detail.
@@ -304,7 +294,7 @@ class Sin(LayerMixin, base_layer.BaseSin):
         return wrapper.Tensor(output_tensor, shape=input_shape, name='output')
 
 
-class Cos(LayerMixin, base_layer.BaseCos):
+class Cos(base_layer.BaseCos):
     """Implement Cos layer in Theano
 
     See :any:`BaseSin` for detail.
@@ -315,7 +305,7 @@ class Cos(LayerMixin, base_layer.BaseCos):
         return wrapper.Tensor(output_tensor, shape=input_shape, name='output')
 
 
-class Softmax(LayerMixin, base_layer.BaseSoftmax):
+class Softmax(base_layer.BaseSoftmax):
     """Implement Softmax layer in Theano.
 
     See :any:`BaseSoftmax` for detail.
@@ -326,7 +316,7 @@ class Softmax(LayerMixin, base_layer.BaseSoftmax):
         return wrapper.Tensor(output_tensor, shape=input_shape, name='output')
 
 
-class Softplus(LayerMixin, base_layer.BaseSoftplus):
+class Softplus(base_layer.BaseSoftplus):
     """Implemente Softplus layer in Theano.
 
     See :any:`BaseSoftplus` for detail.
@@ -338,7 +328,7 @@ class Softplus(LayerMixin, base_layer.BaseSoftplus):
 
 
 ###############################################################################
-class Flatten(LayerMixin, base_layer.BaseFlatten):
+class Flatten(base_layer.BaseFlatten):
     """Implement Flatten layer in Theano
 
     See :any:`BaseFlatten` for detail.
@@ -356,7 +346,7 @@ class Flatten(LayerMixin, base_layer.BaseFlatten):
         return wrapper.Tensor(output_tensor, shape=output_shape, name='output')
 
 
-class Tile(LayerMixin, base_layer.BaseTile):
+class Tile(base_layer.BaseTile):
     """Implement Tile layer in Theano
 
     See :any:`BaseFlatten` for detail.
@@ -385,7 +375,7 @@ def _compute_concat_shape(shapes, axis):
     return _shape
 
 
-class Concat(LayerMixin, base_layer.BaseConcat):
+class Concat(base_layer.BaseConcat):
     """Implement Concat layer in Theano
 
     See :any: `BaseConcat` for detail.
@@ -402,7 +392,7 @@ class Concat(LayerMixin, base_layer.BaseConcat):
         return wrapper.Tensor(output, shape=shape, name='output')
 
 
-class Add(LayerMixin, base_layer.BaseAdd):
+class Add(base_layer.BaseAdd):
     """Implement Add layer in Theano
 
     See :any: `BaseAdd` for detail.
@@ -417,7 +407,7 @@ class Add(LayerMixin, base_layer.BaseAdd):
         return ret.__add__(var_list[-1], name='output')
 
 
-class Sub(LayerMixin, base_layer.BaseAdd):
+class Sub(base_layer.BaseAdd):
     """Implement Sub layer in Theano
 
     See :any: `BaseSub` for detail.
@@ -430,7 +420,7 @@ class Sub(LayerMixin, base_layer.BaseAdd):
 
 
 ###############################################################################
-class TrueDiv(LayerMixin, base_layer.BaseTrueDiv):
+class TrueDiv(base_layer.BaseTrueDiv):
     """Implement TrueDiv layer in Theano.
 
     See :any:`BaseTrueDiv` for detail.
@@ -446,7 +436,7 @@ class TrueDiv(LayerMixin, base_layer.BaseTrueDiv):
         return wrapper.Tensor(output, shape=input_tensor.shape, name='output')
 
 
-class Mean(LayerMixin, base_layer.BaseMean):
+class Mean(base_layer.BaseMean):
     """Implement Mean layer in Theano.
 
     See :any:`BaseMean` for detail.
@@ -456,7 +446,7 @@ class Mean(LayerMixin, base_layer.BaseMean):
 
 
 ###############################################################################
-class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
+class BatchNormalization(base_layer.BaseBatchNormalization):
     """Implement BN layer in Theano.
 
     See :any:`BaseBatchNormalization` for detail.
@@ -510,8 +500,11 @@ class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
             new_mean_acc = decay * mean_acc + (1 - decay) * mean_in
             new_var_acc = decay * var_acc + (1 - decay) * var_in
 
-            self._add_update(mean_acc, new_mean_acc)
-            self._add_update(var_acc, new_var_acc)
+            self._update_operation = wrapper.Operation(
+                op=OrderedDict(
+                    [(mean_acc, new_mean_acc), (var_acc, new_var_acc)]),
+                name='bn_update',
+            )
 
             mean_acc = new_mean_acc
             var_acc = new_var_acc
@@ -527,7 +520,7 @@ class BatchNormalization(LayerMixin, base_layer.BaseBatchNormalization):
 
 
 ###############################################################################
-class NHWC2NCHW(LayerMixin, base_layer.BaseNHWC2NCHW):
+class NHWC2NCHW(base_layer.BaseNHWC2NCHW):
     """See :any:`BaseNHWC2NCHW` for detail."""
     def _build(self, input_tensor):
         output_tensor = input_tensor.unwrap().dimshuffle(0, 3, 1, 2)
@@ -537,7 +530,7 @@ class NHWC2NCHW(LayerMixin, base_layer.BaseNHWC2NCHW):
         return wrapper.Tensor(output_tensor, shape=output_shape, name='output')
 
 
-class NCHW2NHWC(LayerMixin, base_layer.BaseNCHW2NHWC):
+class NCHW2NHWC(base_layer.BaseNCHW2NHWC):
     """See :any:`BaseNCHW2NHWC` for detail."""
     def _build(self, input_tensor):
         output_tensor = input_tensor.unwrap().dimshuffle(0, 2, 3, 1)

--- a/luchador/util/mixin.py
+++ b/luchador/util/mixin.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 from .yaml_util import pprint_dict
 
-__all__ = ['StoreMixin', 'CompareMixin', 'SerializeMixin']
+__all__ = ['StoreMixin']
 
 # pylint: disable=too-few-public-methods
 
@@ -60,79 +60,3 @@ class StoreMixin(object):
 
     def __str__(self):
         return pprint_dict({self.__class__.__name__: self.args})
-
-
-class CompareMixin(StoreMixin):
-    """Extend StoreMixin by providing method to compare ``args``
-
-    .. automethod:: __eq__
-
-    .. automethod:: __ne__
-
-    Examples
-    --------
-    >>> class Foo(CompareMixin):
-    >>>     def __init__(self, arg):
-    >>>         self._store_args(arg=arg)
-    >>>
-    >>> foo1 = Foo('bar')
-    >>> foo2 = Foo('bar')
-    >>> foo3 = Foo('foo')
-    >>> foo1 == foo2
-    True
-    >>> foo1 == foo3
-    False
-
-    See Also
-    --------
-    StoreMixin : Base mixin which stores costructor arguments
-    SerializeMixin : Subclass mixin which serialize object with arguments
-    """
-    def __eq__(self, other):
-        """Checks if the other object has `same configuration` with this object
-
-        `Same configuration` here means objects are of the same (or subclassed)
-        type and have the same ``args`` attribute value.
-        """
-        if isinstance(other, self.__class__):
-            return self.args == other.args
-        return NotImplemented
-
-    def __ne__(self, other):
-        """Checks if the other object is not equal to this object"""
-        return not self.__eq__(other)
-
-
-class SerializeMixin(CompareMixin):
-    """Extend StoreMixin to be serializable in JSON format
-
-    Examples
-    --------
-    >>> class Foo(SerializeMixin):
-    >>>     def __init__(self, number, string):
-    >>>         self._store_args(numer=number, string=string)
-    >>>
-    >>> foo = Foo(0.5, 'bar')
-    >>> print(foo.serialize())
-    {'number': 0.5, 'string': 'bar'}
-
-    See Also
-    --------
-    StoreMixin : Base mixin which stores costructor arguments
-    CompareMixin : Base mixin which adds equality comparison to StoreMixin
-    """
-    def serialize(self):
-        """Serialize object configuration (constructor arguments)
-
-        Returns
-        -------
-        dict
-           Arguments stored via ::func:`_store_args` method.
-        """
-        args = {}
-        for key, val in self.args.items():
-            args[key] = val.serialize() if hasattr(val, 'serialize') else val
-        return {
-            'typename': self.__class__.__name__,
-            'args': args
-        }

--- a/tests/unit/nn/layer_interface_test.py
+++ b/tests/unit/nn/layer_interface_test.py
@@ -145,6 +145,7 @@ class LayerInterfaceTest(fixture.TestCase):
             var = layer.get_parameter_variables('var')
             scale = layer.get_parameter_variables('scale')
             offset = layer.get_parameter_variables('offset')
+            update = layer.get_update_operation()
 
         with nn.variable_scope(vs, reuse=True):
             self.assertIs(mean, nn.get_variable('mean'))
@@ -152,3 +153,4 @@ class LayerInterfaceTest(fixture.TestCase):
             self.assertIs(scale, nn.get_variable('scale'))
             self.assertIs(offset, nn.get_variable('offset'))
             self.assertIs(output, nn.get_tensor('output'))
+            self.assertIs(update, nn.get_operation('bn_update'))

--- a/tests/unit/nn/layer_interface_test.py
+++ b/tests/unit/nn/layer_interface_test.py
@@ -38,8 +38,8 @@ class LayerInterfaceTest(fixture.TestCase):
             input_ = nn.Input(shape=(32, 5), name='input')
             layer = nn.get_layer('Dense')(n_nodes=4, with_bias=True)
             output = layer(input_)
-            weight = layer.parameter_variables['weight']
-            bias = layer.parameter_variables['bias']
+            weight = layer.get_parameter_variables('weight')
+            bias = layer.get_parameter_variables('bias')
 
         with nn.variable_scope(vs, reuse=True):
             self.assertIs(weight, nn.get_variable('weight'))
@@ -56,8 +56,8 @@ class LayerInterfaceTest(fixture.TestCase):
                 filter_height=4, filter_width=4, n_filters=4,
                 strides=1, with_bias=True)
             output = layer(input_)
-            weight = layer.parameter_variables['weight']
-            bias = layer.parameter_variables['bias']
+            weight = layer.get_parameter_variables('weight')
+            bias = layer.get_parameter_variables('bias')
 
         with nn.variable_scope(vs, reuse=True):
             self.assertIs(weight, nn.get_variable('weight'))
@@ -141,10 +141,10 @@ class LayerInterfaceTest(fixture.TestCase):
             input_ = nn.Input(shape=(32, 4), name='input')
             layer = nn.get_layer('BatchNormalization')()
             output = layer(input_)
-            mean = layer.parameter_variables['mean']
-            var = layer.parameter_variables['var']
-            scale = layer.parameter_variables['scale']
-            offset = layer.parameter_variables['offset']
+            mean = layer.get_parameter_variables('mean')
+            var = layer.get_parameter_variables('var')
+            scale = layer.get_parameter_variables('scale')
+            offset = layer.get_parameter_variables('offset')
 
         with nn.variable_scope(vs, reuse=True):
             self.assertIs(mean, nn.get_variable('mean'))


### PR DESCRIPTION
- Remove `CompareMixin` and `SerializeMixin`    
The overall library design is to customize stuff configuration (with YAML).

- Create Operation instance for layer update at layer build    
Previously Operation instance was created at when `get_update_operation` is called, but now that construction of Operation instance register the instance to scope, this cause a
trouble.    
Change the code to generate Operation instance at build time.
As a result, LayerMixin is no longer needed.    

- Introduce `get_parameter_variables` to `Layer` class and hide `parameter_variables` attribute