### PR TITLE
Tweak interface

### DIFF
--- a/luchador/agent/rl/q_learning.py
+++ b/luchador/agent/rl/q_learning.py
@@ -32,8 +32,8 @@ def _make_model(model_def, scope):
 
 def _build_sync_op(src_model, tgt_model, scope):
     with nn.variable_scope(scope):
-        src_vars = src_model.get_parameters_to_train()
-        tgt_vars = tgt_model.get_parameters_to_train()
+        src_vars = src_model.get_parameters_to_serialize()
+        tgt_vars = tgt_model.get_parameters_to_serialize()
         return nn.build_sync_op(src_vars, tgt_vars, name='sync')
 
 

--- a/luchador/agent/rl/q_learning.py
+++ b/luchador/agent/rl/q_learning.py
@@ -32,8 +32,8 @@ def _make_model(model_def, scope):
 
 def _build_sync_op(src_model, tgt_model, scope):
     with nn.variable_scope(scope):
-        src_vars = src_model.get_parameter_variables()
-        tgt_vars = tgt_model.get_parameter_variables()
+        src_vars = src_model.get_parameters_to_train()
+        tgt_vars = tgt_model.get_parameters_to_train()
         return nn.build_sync_op(src_vars, tgt_vars, name='sync')
 
 

--- a/luchador/nn/base/layer/base.py
+++ b/luchador/nn/base/layer/base.py
@@ -25,7 +25,7 @@ class BaseLayer(luchador.util.StoreMixin, object):
         self.input = None
         self.output = None
 
-        self._update_operation = None
+        self._update_operations = []
         self._parameter_variables = OrderedDict()
 
         self._parameters_to_train = []
@@ -60,32 +60,16 @@ class BaseLayer(luchador.util.StoreMixin, object):
             return self._parameter_variables[name]
         return self._parameter_variables.values()
 
-    def get_parameters_to_train(self, name=None):
+    def get_parameters_to_train(self):
         """Get parameter variables for training.
 
         This function is mainly for retrieving variables which are fed to
         gradient computation as `wrt`.
 
-        Parameters
-        ----------
-        name : str or None
-            The name of the parameter (such as ``weight``) to retrieve.
-            If not given, all parameter Variables consisting this layer are
-            returned.
-
         Returns
         -------
-        [list of] Variable
-            When name is given, a single Variable is returned, otherwise
-            list of Variables are returned.
+        list of Variable
         """
-        if name and name not in self._parameters_to_train:
-            raise ValueError(
-                'Unexpected training parameter name ({}) was given. '
-                'Must be one of {}'.format(name, self._parameters_to_train)
-            )
-        if name:
-            return self._parameter_variables[name]
         return [
             self._parameter_variables[key]
             for key in self._parameters_to_train]
@@ -121,7 +105,7 @@ class BaseLayer(luchador.util.StoreMixin, object):
 
     ###########################################################################
     # Getter for update operation
-    def get_update_operation(self):
+    def get_update_operations(self):
         """Get Operation which updates Layer parameter
 
         For layers which require updates other than back propagate
@@ -136,7 +120,7 @@ class BaseLayer(luchador.util.StoreMixin, object):
             If update Operation is defined (BatchNormalization), Operation is
             returned, else None
         """
-        return self._update_operation
+        return self._update_operations
 
     ###########################################################################
     # Functions for building computation graph

--- a/luchador/nn/base/layer/base.py
+++ b/luchador/nn/base/layer/base.py
@@ -40,25 +40,19 @@ class BaseLayer(luchador.util.StoreMixin, object):
         if serialize:
             self._parameters_to_serialize.append(name)
 
-    def get_parameter_variables(self, name=None):
+    def get_parameter_variable(self, name):
         """Get parameter variables
 
         Parameters
         ----------
-        name : str or None
+        name : str
             The name of the parameter (such as ``weight``) to retrieve.
-            If not given, all parameter Variables consisting this layer are
-            returned.
 
         Returns
         -------
-        [list of] Variable
-            When name is given, a single Variable is returned, otherwise
-            list of Variables are returned.
+        Variable
         """
-        if name:
-            return self._parameter_variables[name]
-        return self._parameter_variables.values()
+        return self._parameter_variables[name]
 
     def get_parameters_to_train(self):
         """Get parameter variables for training.

--- a/luchador/nn/base/optimizer.py
+++ b/luchador/nn/base/optimizer.py
@@ -17,6 +17,13 @@ def _remove_dup(grads_and_vars):
     return [x for x in grads_and_vars if not (x[1] in seen or seen_add(x[1]))]
 
 
+def _log_wrt(wrt):
+    if not luchador.util.is_iteratable(wrt):
+        wrt = [wrt]
+    for var in wrt:
+        _LG.info('    %20s', var)
+
+
 class BaseOptimizer(luchador.util.StoreMixin):
     """Define common interface of Optimizer"""
     __metaclass__ = abc.ABCMeta
@@ -89,11 +96,7 @@ class BaseOptimizer(luchador.util.StoreMixin):
             native to backend.
         """
         _LG.info('Computing gradient for %s', loss)
-        if luchador.util.is_iteratable(wrt):
-            for var in wrt:
-                _LG.info('    %s', var)
-        else:
-            _LG.info('    %s', wrt)
+        _log_wrt(wrt)
         return self._compute_gradients(loss, wrt, **kwargs)
 
     @abc.abstractmethod

--- a/luchador/nn/base/optimizer.py
+++ b/luchador/nn/base/optimizer.py
@@ -2,8 +2,11 @@
 from __future__ import absolute_import
 
 import abc
+import logging
 
 import luchador.util
+
+_LG = logging.getLogger(__name__)
 
 
 def _remove_dup(grads_and_vars):
@@ -85,6 +88,12 @@ class BaseOptimizer(luchador.util.StoreMixin):
             not wrapped with Luchador's Variable but bare TensorVariable
             native to backend.
         """
+        _LG.info('Computing gradient for %s', loss)
+        if luchador.util.is_iteratable(wrt):
+            for var in wrt:
+                _LG.info('    %s', var)
+        else:
+            _LG.info('    %s', wrt)
         return self._compute_gradients(loss, wrt, **kwargs)
 
     @abc.abstractmethod

--- a/luchador/nn/base/wrapper.py
+++ b/luchador/nn/base/wrapper.py
@@ -121,7 +121,7 @@ class BaseWrapper(object):
         self._tensor = obj
 
     def __repr__(self):
-        return '<{}, {}, {}>'.format(self.dtype, self.shape, self.name)
+        return '<{}, {}, {}>'.format(self.name or '', self.dtype, self.shape)
 
     @property
     def size(self):

--- a/luchador/nn/model/container.py
+++ b/luchador/nn/model/container.py
@@ -32,19 +32,6 @@ class Container(BaseModel):
         self.models[name] = model
         return self
 
-    def get_parameter_variables(self):
-        """Get parameter Variables
-
-        Returns
-        -------
-        list
-            List of Variables from interanal models.
-        """
-        ret = []
-        for name_ in self.models.keys():
-            ret.extend(self.models[name_].get_parameter_variables())
-        return ret
-
     def get_parameters_to_train(self):
         """Get parameter Variables to be fet to gradient computation.
 

--- a/luchador/nn/model/container.py
+++ b/luchador/nn/model/container.py
@@ -99,7 +99,4 @@ class Container(BaseModel):
 
     ###########################################################################
     def __repr__(self):
-        return repr({
-            'model_type': self.__class__.__name__,
-            'models': self.models,
-        })
+        return repr({self.__class__.__name__: self.models})

--- a/luchador/nn/model/sequential.py
+++ b/luchador/nn/model/sequential.py
@@ -125,19 +125,6 @@ class Sequential(BaseModel):
 
     ###########################################################################
     # Functions for retrieving variables, tensors and operations
-    def get_parameter_variables(self):
-        """Get parameter Variables
-
-        Returns
-        -------
-        list
-            List of Variables from layer parameters
-        """
-        ret = []
-        for layer in self.layers:
-            ret.extend(layer.get_parameter_variables())
-        return ret
-
     def get_parameters_to_train(self):
         """Get parameter Variables to be fet to gradient computation.
 

--- a/luchador/nn/model/sequential.py
+++ b/luchador/nn/model/sequential.py
@@ -184,14 +184,9 @@ class Sequential(BaseModel):
         """
         ret = []
         for layer in self.layers:
-            update = layer.get_update_operation()
-            if update:
-                ret.append(update)
+            ret.extend(layer.get_update_operations())
         return ret
 
     ###########################################################################
     def __repr__(self):
-        return repr({
-            'typename': self.__class__.__name__,
-            'layers': self.layers,
-        })
+        return repr({self.__class__.__name__: self.layers})

--- a/luchador/nn/tensorflow/layer/convolution.py
+++ b/luchador/nn/tensorflow/layer/convolution.py
@@ -138,13 +138,13 @@ class _Conv2DMixin(object):
         self.set_parameter_variables(bias=bias)
 
     def _build_parameters(self, filter_shape, bias_shape, dtype):
-        if self._parameter_variables['filter'] is None:
+        if self.get_parameter_variable('filter') is None:
             self._build_filter(shape=filter_shape, dtype=dtype)
 
         if not self.args['with_bias']:
             return
 
-        if self._parameter_variables['bias'] is None:
+        if self.get_parameter_variable('bias') is None:
             self._build_bias(shape=bias_shape, dtype=dtype)
 
 
@@ -167,14 +167,14 @@ class Conv2D(_Conv2DMixin, BaseConv2D):
         _check_filter_shape(
             input_shape, filter_shape, strides, data_format, padding)
 
-        filter_ = self.get_parameter_variables('filter')
+        filter_ = self.get_parameter_variable('filter')
         output = tf.nn.conv2d(
             input_tensor.unwrap(), filter_.unwrap(),
             strides=strides, padding=padding, use_cudnn_on_gpu=cudnn,
             data_format=data_format)
 
         if self.args['with_bias']:
-            bias = self.get_parameter_variables('bias').unwrap()
+            bias = self.get_parameter_variable('bias').unwrap()
             output = tf.nn.bias_add(
                 output, bias, data_format=data_format, name='output')
         return wrapper.Tensor(output, name='output')
@@ -212,10 +212,10 @@ class Conv2DTranspose(_Conv2DMixin, BaseConv2DTranspose):
             )
 
     def _get_filter_shape(self, output_shape, data_format):
-        if self.get_parameter_variables('filter') is not None:
-            return self.get_parameter_variables('filter').shape
-        if self.get_parameter_variables('original_filter') is not None:
-            return self.get_parameter_variables('original_filter').shape
+        if self.get_parameter_variable('filter') is not None:
+            return self.get_parameter_variable('filter').shape
+        if self.get_parameter_variable('original_filter') is not None:
+            return self.get_parameter_variable('original_filter').shape
         return super(Conv2DTranspose, self)._get_filter_shape(
             output_shape, data_format)
 
@@ -230,7 +230,7 @@ class Conv2DTranspose(_Conv2DMixin, BaseConv2DTranspose):
         bias_shape = (filter_shape[2], )
         self._build_parameters(filter_shape, bias_shape, input_tensor.dtype)
 
-        filter_ = self.get_parameter_variables('filter')
+        filter_ = self.get_parameter_variable('filter')
         padding = _map_padding(self.args['padding'])
         strides = _get_strides(self.args['strides'], data_format)
         tensor_ = tf.nn.conv2d_transpose(
@@ -240,7 +240,7 @@ class Conv2DTranspose(_Conv2DMixin, BaseConv2DTranspose):
         )
 
         if self.args['with_bias']:
-            bias = self.get_parameter_variables('bias')
+            bias = self.get_parameter_variable('bias')
             tensor_ = tf.nn.bias_add(
                 tensor_, bias.unwrap(), data_format=data_format, name='output')
         return wrapper.Tensor(tensor_, name='output')

--- a/luchador/nn/tensorflow/layer/linear.py
+++ b/luchador/nn/tensorflow/layer/linear.py
@@ -59,10 +59,10 @@ class Dense(base_layer.BaseDense):
     def _build(self, input_tensor):
         self._instantiate_parameters(input_tensor.shape[1], input_tensor.dtype)
 
-        weight = self.get_parameter_variables('weight').unwrap()
+        weight = self.get_parameter_variable('weight').unwrap()
         output = tf.matmul(input_tensor.unwrap(), weight)
 
         if self.args['with_bias']:
-            bias = self.get_parameter_variables('bias').unwrap()
+            bias = self.get_parameter_variable('bias').unwrap()
             output = tf.add(output, bias, name='output')
         return wrapper.Tensor(output, name='output')

--- a/luchador/nn/tensorflow/layer/normalization.py
+++ b/luchador/nn/tensorflow/layer/normalization.py
@@ -69,14 +69,18 @@ class BatchNormalization(base_layer.BaseBatchNormalization):
             new_mean_acc = decay * mean_acc + (1 - decay) * mean_in
             new_var_acc = decay * var_acc + (1 - decay) * var_in
 
-            self._update_operation = wrapper.Operation(
-                op=[
-                    tf.assign(mean_acc, new_mean_acc),
-                    tf.assign(var_acc, new_var_acc)
-                ],
-                name='bn_update',
+            self._update_operations.append(
+                wrapper.Operation(
+                    op=tf.assign(mean_acc, new_mean_acc),
+                    name='update_mean',
+                )
             )
-
+            self._update_operations.append(
+                wrapper.Operation(
+                    op=tf.assign(var_acc, new_var_acc),
+                    name='update_var',
+                )
+            )
             mean_acc = new_mean_acc
             var_acc = new_var_acc
 

--- a/luchador/nn/tensorflow/layer/normalization.py
+++ b/luchador/nn/tensorflow/layer/normalization.py
@@ -27,25 +27,25 @@ class BatchNormalization(base_layer.BaseBatchNormalization):
         self._axes = tuple(i for i in range(dim) if not i == channel)
         shape = tuple(input_shape[i] for i in range(dim) if i == channel)
 
-        if self._parameter_variables['mean'] is None:
+        if self.get_parameter_variable('mean') is None:
             mean = wrapper.get_variable(
                 name='mean', shape=shape,
                 initializer=initializer.Constant(0), trainable=False)
             self.set_parameter_variables(mean=mean)
 
-        if self._parameter_variables['var'] is None:
+        if self.get_parameter_variable('var') is None:
             var = wrapper.get_variable(
                 name='var', shape=shape,
                 initializer=initializer.Constant(1), trainable=False)
             self.set_parameter_variables(var=var)
 
-        if self._parameter_variables['scale'] is None:
+        if self.get_parameter_variable('scale') is None:
             scale = wrapper.get_variable(
                 name='scale', shape=shape, trainable=True,
                 initializer=initializer.Constant(self.args['scale']))
             self.set_parameter_variables(scale=scale)
 
-        if self._parameter_variables['offset'] is None:
+        if self.get_parameter_variable('offset') is None:
             offset = wrapper.get_variable(
                 name='offset', shape=shape, trainable=True,
                 initializer=initializer.Constant(self.args['offset']))
@@ -58,10 +58,10 @@ class BatchNormalization(base_layer.BaseBatchNormalization):
         input_ = input_tensor.unwrap()
         decay, epsilon = self.args['decay'], self.args['epsilon']
 
-        mean_acc = self.get_parameter_variables('mean').unwrap()
-        var_acc = self.get_parameter_variables('var').unwrap()
-        scale = self.get_parameter_variables('scale').unwrap()
-        offset = self.get_parameter_variables('offset').unwrap()
+        mean_acc = self.get_parameter_variable('mean').unwrap()
+        var_acc = self.get_parameter_variable('var').unwrap()
+        scale = self.get_parameter_variable('scale').unwrap()
+        offset = self.get_parameter_variable('offset').unwrap()
 
         if self.args['learn']:
             mean_in, var_in = tf.nn.moments(input_, self._axes)

--- a/luchador/nn/theano/layer/convolution.py
+++ b/luchador/nn/theano/layer/convolution.py
@@ -193,14 +193,14 @@ class Conv2D(_Conv2DMixin, BaseConv2D):
 
         self._build_parameters(filter_shape, bias_shape, input_tensor.dtype)
 
-        filters = self.get_parameter_variables('filter')
+        filters = self.get_parameter_variable('filter')
         output_tensor = T.nnet.conv2d(
             input_tensor.unwrap(), filters=filters.unwrap(),
             input_shape=input_shape, filter_shape=filter_shape,
             border_mode=border_mode, subsample=subsample)
 
         if self.args['with_bias']:
-            bias = self.get_parameter_variables('bias').unwrap()
+            bias = self.get_parameter_variable('bias').unwrap()
             bias = bias.dimshuffle(('x', 0, 'x', 'x'))
             output_tensor = bias + output_tensor
 
@@ -231,10 +231,10 @@ class Conv2DTranspose(_Conv2DMixin, BaseConv2DTranspose):
         )
 
     def _get_filter_shape(self, n_filters):
-        if self.get_parameter_variables('filter') is not None:
-            return self.get_parameter_variables('filter').shape
-        if self.get_parameter_variables('original_filter') is not None:
-            return self.get_parameter_variables('original_filter').shape
+        if self.get_parameter_variable('filter') is not None:
+            return self.get_parameter_variable('filter').shape
+        if self.get_parameter_variable('original_filter') is not None:
+            return self.get_parameter_variable('original_filter').shape
         return super(Conv2DTranspose, self)._get_filter_shape(n_filters)
 
     def _build(self, input_tensor):
@@ -246,7 +246,7 @@ class Conv2DTranspose(_Conv2DMixin, BaseConv2DTranspose):
         bias_shape = (filter_shape[1],)
         self._build_parameters(filter_shape, bias_shape, input_tensor.dtype)
 
-        filters = self.get_parameter_variables('filter')
+        filters = self.get_parameter_variable('filter')
         border_mode = _map_border_mode(self.args['padding'])
         subsample = _get_subsample(self.args['strides'])
         tensor_ = T.nnet.abstract_conv.conv2d_grad_wrt_inputs(
@@ -256,6 +256,6 @@ class Conv2DTranspose(_Conv2DMixin, BaseConv2DTranspose):
         )
 
         if self.args['with_bias']:
-            bias = self.get_parameter_variables('bias').unwrap()
+            bias = self.get_parameter_variable('bias').unwrap()
             tensor_ = bias.dimshuffle(('x', 0, 'x', 'x')) + tensor_
         return wrapper.Tensor(tensor_, shape=output_shape, name='output')

--- a/luchador/nn/theano/layer/linear.py
+++ b/luchador/nn/theano/layer/linear.py
@@ -65,11 +65,11 @@ class Dense(base_layer.BaseDense):
 
         self._instantiate_parameters(input_shape[1], input_tensor.dtype)
 
-        weight = self.get_parameter_variables('weight').unwrap()
+        weight = self.get_parameter_variable('weight').unwrap()
         output = T.dot(input_tensor.unwrap(), weight)
 
         if self.args['with_bias']:
-            bias = self.get_parameter_variables('bias').unwrap()
+            bias = self.get_parameter_variable('bias').unwrap()
             output = output + bias
         output_shape = (input_shape[0], self.args['n_nodes'])
         return wrapper.Tensor(output, shape=output_shape, name='output')

--- a/luchador/nn/theano/layer/normalization.py
+++ b/luchador/nn/theano/layer/normalization.py
@@ -75,10 +75,17 @@ class BatchNormalization(base_layer.BaseBatchNormalization):
             new_mean_acc = decay * mean_acc + (1 - decay) * mean_in
             new_var_acc = decay * var_acc + (1 - decay) * var_in
 
-            self._update_operation = wrapper.Operation(
-                op=OrderedDict(
-                    [(mean_acc, new_mean_acc), (var_acc, new_var_acc)]),
-                name='bn_update',
+            self._update_operations.append(
+                wrapper.Operation(
+                    op={mean_acc: new_mean_acc},
+                    name='update_mean',
+                )
+            )
+            self._update_operations.append(
+                wrapper.Operation(
+                    op={var_acc: new_var_acc},
+                    name='update_var',
+                )
             )
 
             mean_acc = new_mean_acc

--- a/luchador/nn/theano/layer/normalization.py
+++ b/luchador/nn/theano/layer/normalization.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import absolute_import
 
 import logging
-from collections import OrderedDict
 
 import theano.tensor as T
 
@@ -62,10 +61,10 @@ class BatchNormalization(base_layer.BaseBatchNormalization):
 
         input_tensor_ = input_tensor.unwrap()
 
-        mean_acc = self.get_parameter_variables('mean').unwrap()
-        var_acc = self.get_parameter_variables('var').unwrap()
-        scale = self.get_parameter_variables('scale').unwrap()
-        offset = self.get_parameter_variables('offset').unwrap()
+        mean_acc = self.get_parameter_variable('mean').unwrap()
+        var_acc = self.get_parameter_variable('var').unwrap()
+        scale = self.get_parameter_variable('scale').unwrap()
+        offset = self.get_parameter_variable('offset').unwrap()
 
         if self.args['learn']:
             decay = self.args['decay']

--- a/tests/unit/agent/rl/q_learning_test.py
+++ b/tests/unit/agent/rl/q_learning_test.py
@@ -63,8 +63,8 @@ class DQNTest(fixture.TestCase):
         with nn.variable_scope(self.get_scope()):
             dqn = _make_dqn(model_def=model_def)
 
-        params0 = dqn.models['model_0'].get_parameter_variables()
-        params1 = dqn.models['model_1'].get_parameter_variables()
+        params0 = dqn.models['model_0'].get_parameters_to_train()
+        params1 = dqn.models['model_1'].get_parameters_to_train()
 
         # check that variables are different before sync
         vars0 = dqn.session.run(outputs=params0)

--- a/tests/unit/nn/layer/convolution_test.py
+++ b/tests/unit/nn/layer/convolution_test.py
@@ -58,8 +58,8 @@ class Conv2DTransposeTest(TestCase):
 
         self._check(input_var, conv_t_output)
         self.assertIsNot(
-            conv2d.get_parameter_variables('filter'),
-            conv2d_t.get_parameter_variables('filter'),
+            conv2d.get_parameter_variable('filter'),
+            conv2d_t.get_parameter_variable('filter'),
         )
 
     def test_original_input(self):
@@ -89,8 +89,8 @@ class Conv2DTransposeTest(TestCase):
 
         self._check(input_var, conv_t_output)
         self.assertIsNot(
-            conv2d.get_parameter_variables('filter'),
-            conv2d_t.get_parameter_variables('filter'),
+            conv2d.get_parameter_variable('filter'),
+            conv2d_t.get_parameter_variable('filter'),
         )
 
     def test_original_filter(self):
@@ -111,7 +111,7 @@ class Conv2DTransposeTest(TestCase):
         with nn.variable_scope(self.get_scope('convolution')):
             conv_output = conv2d(input_var)
 
-        original_filter = conv2d.get_parameter_variables('filter')
+        original_filter = conv2d.get_parameter_variable('filter')
         conv2d_t = nn.layer.Conv2DTranspose(
             filter_height=h, filter_width=w, n_filters=c,
             strides=strides, padding=padding)
@@ -123,8 +123,8 @@ class Conv2DTransposeTest(TestCase):
 
         self._check(input_var, conv_t_output)
         self.assertIsNot(
-            conv2d.get_parameter_variables('filter'),
-            conv2d_t.get_parameter_variables('filter'),
+            conv2d.get_parameter_variable('filter'),
+            conv2d_t.get_parameter_variable('filter'),
         )
 
     def test_tied_weight(self):
@@ -144,7 +144,7 @@ class Conv2DTransposeTest(TestCase):
         with nn.variable_scope(self.get_scope('convolution')):
             conv_output = conv2d(input_var)
 
-        original_filter = conv2d.get_parameter_variables('filter')
+        original_filter = conv2d.get_parameter_variable('filter')
         conv2d_t = nn.layer.Conv2DTranspose(
             filter_height=h, filter_width=w, n_filters=c,
             strides=strides, padding=padding)
@@ -156,8 +156,8 @@ class Conv2DTransposeTest(TestCase):
 
         self._check(input_var, conv_t_output)
         self.assertIs(
-            conv2d.get_parameter_variables('filter'),
-            conv2d_t.get_parameter_variables('filter'),
+            conv2d.get_parameter_variable('filter'),
+            conv2d_t.get_parameter_variable('filter'),
         )
 
     def test_output_shape_format_nchw(self):
@@ -188,8 +188,8 @@ class Conv2DTransposeTest(TestCase):
 
         self._check(input_var, conv_t_output)
         self.assertIsNot(
-            conv2d.get_parameter_variables('filter'),
-            conv2d_t.get_parameter_variables('filter'),
+            conv2d.get_parameter_variable('filter'),
+            conv2d_t.get_parameter_variable('filter'),
         )
 
     def test_output_shape_format_nhwc(self):
@@ -220,6 +220,6 @@ class Conv2DTransposeTest(TestCase):
 
         self._check(input_var, conv_t_output)
         self.assertIsNot(
-            conv2d.get_parameter_variables('filter'),
-            conv2d_t.get_parameter_variables('filter'),
+            conv2d.get_parameter_variable('filter'),
+            conv2d_t.get_parameter_variable('filter'),
         )

--- a/tests/unit/nn/layer/layer_interface_test.py
+++ b/tests/unit/nn/layer/layer_interface_test.py
@@ -170,7 +170,7 @@ class LayerInterfaceTest(fixture.TestCase):
             var = layer.get_parameter_variables('var')
             scale = layer.get_parameter_variables('scale')
             offset = layer.get_parameter_variables('offset')
-            update = layer.get_update_operation()
+            updates = layer.get_update_operations()
 
         with nn.variable_scope(vs, reuse=True):
             self.assertIs(mean, nn.get_variable('BN/mean'))
@@ -178,4 +178,5 @@ class LayerInterfaceTest(fixture.TestCase):
             self.assertIs(scale, nn.get_variable('BN/scale'))
             self.assertIs(offset, nn.get_variable('BN/offset'))
             self.assertIs(output, nn.get_tensor('BN/output'))
-            self.assertIs(update, nn.get_operation('BN/bn_update'))
+            self.assertIs(updates[0], nn.get_operation('BN/update_mean'))
+            self.assertIs(updates[1], nn.get_operation('BN/update_var'))

--- a/tests/unit/nn/layer/layer_interface_test.py
+++ b/tests/unit/nn/layer/layer_interface_test.py
@@ -40,8 +40,8 @@ class LayerInterfaceTest(fixture.TestCase):
             layer = nn.get_layer('Dense')(
                 n_nodes=4, with_bias=True, name='Dense')
             output = layer(input_)
-            weight = layer.get_parameter_variables('weight')
-            bias = layer.get_parameter_variables('bias')
+            weight = layer.get_parameter_variable('weight')
+            bias = layer.get_parameter_variable('bias')
 
         with nn.variable_scope(vs, reuse=True):
             self.assertIs(weight, nn.get_variable('Dense/weight'))
@@ -58,8 +58,8 @@ class LayerInterfaceTest(fixture.TestCase):
                 filter_height=4, filter_width=4, n_filters=4,
                 strides=1, with_bias=True, name='Conv2D')
             output = layer(input_)
-            filters = layer.get_parameter_variables('filter')
-            bias = layer.get_parameter_variables('bias')
+            filters = layer.get_parameter_variable('filter')
+            bias = layer.get_parameter_variable('bias')
 
         with nn.variable_scope(vs, reuse=True):
             self.assertIs(filters, nn.get_variable('Conv2D/filter'))
@@ -81,8 +81,8 @@ class LayerInterfaceTest(fixture.TestCase):
                 strides=1, with_bias=True, output_shape=input_.shape,
                 name='Conv2DT')
             output = layer(output)
-            filters = layer.get_parameter_variables('filter')
-            bias = layer.get_parameter_variables('bias')
+            filters = layer.get_parameter_variable('filter')
+            bias = layer.get_parameter_variable('bias')
 
         with nn.variable_scope(vs, reuse=True):
             self.assertIs(filters, nn.get_variable('Conv2DT/filter'))
@@ -166,10 +166,10 @@ class LayerInterfaceTest(fixture.TestCase):
             input_ = nn.Input(shape=(32, 4), name='input')
             layer = nn.get_layer('BatchNormalization')(name='BN')
             output = layer(input_)
-            mean = layer.get_parameter_variables('mean')
-            var = layer.get_parameter_variables('var')
-            scale = layer.get_parameter_variables('scale')
-            offset = layer.get_parameter_variables('offset')
+            mean = layer.get_parameter_variable('mean')
+            var = layer.get_parameter_variable('var')
+            scale = layer.get_parameter_variable('scale')
+            offset = layer.get_parameter_variable('offset')
             updates = layer.get_update_operations()
 
         with nn.variable_scope(vs, reuse=True):

--- a/tests/unit/nn/layer/layer_test.py
+++ b/tests/unit/nn/layer/layer_test.py
@@ -43,7 +43,10 @@ class TestInitializer(TestCase):
         session.initialize()
 
         weight, bias = session.run(
-            outputs=dense.get_parameter_variables()
+            outputs=[
+                dense.get_parameter_variable('weight'),
+                dense.get_parameter_variable('bias'),
+            ]
         )
 
         np.testing.assert_almost_equal(
@@ -63,12 +66,15 @@ class TestReuse(TestCase):
 
             tensor = nn.Input(shape=shape)
             out1 = layer1(tensor)
-            layer2.set_parameter_variables(**layer1._parameter_variables)
+            layer2.set_parameter_variables(
+                weight=layer1.get_parameter_variable('weight'),
+                bias=layer1.get_parameter_variable('bias'),
+            )
             out2 = layer2(tensor)
 
-        vars1 = layer1.get_parameter_variables()
-        vars2 = layer2.get_parameter_variables()
-        for var1, var2 in zip(vars1, vars2):
+        for key in ['weight', 'bias']:
+            var1 = layer1.get_parameter_variable(key)
+            var2 = layer2.get_parameter_variable(key)
             self.assertIs(var1, var2)
 
         session = nn.Session()
@@ -97,12 +103,14 @@ class TestReuse(TestCase):
 
             tensor = nn.Input(shape=shape)
             out1 = layer1(tensor)
-            layer2.set_parameter_variables(**layer1._parameter_variables)
+            layer2.set_parameter_variables(
+                filter=layer1.get_parameter_variable('filter'),
+                bias=layer1.get_parameter_variable('bias'))
             out2 = layer2(tensor)
 
-        vars1 = layer1.get_parameter_variables()
-        vars2 = layer2.get_parameter_variables()
-        for var1, var2 in zip(vars1, vars2):
+        for key in ['filter', 'bias']:
+            var1 = layer1.get_parameter_variable(key)
+            var2 = layer2.get_parameter_variable(key)
             self.assertIs(var1, var2)
 
         session = nn.Session()

--- a/tests/unit/nn/layer/normalization_test.py
+++ b/tests/unit/nn/layer/normalization_test.py
@@ -166,8 +166,8 @@ class BatchNormalizationTest(TestCase):
             bn = nn.layer.BatchNormalization(learn=True, decay=0.999)
             normalized = bn(input_tensor)
 
-        mean_tensor = bn.get_parameter_variables('mean')
-        var_tensor = bn.get_parameter_variables('var')
+        mean_tensor = bn.get_parameter_variable('mean')
+        var_tensor = bn.get_parameter_variable('var')
         updates = bn.get_update_operations()
 
         input_value = np.random.randn(*shape) - 100

--- a/tests/unit/nn/layer/normalization_test.py
+++ b/tests/unit/nn/layer/normalization_test.py
@@ -35,7 +35,7 @@ def _normalize_batch(shape, offset, scale):
     bn = nn.layer.BatchNormalization(
         scale=scale, offset=offset, learn=True, decay=0.0)
     normalized = bn(input_tensor)
-    updates = bn.get_update_operation()
+    updates = bn.get_update_operations()
     session = nn.Session()
     session.initialize()
     return session.run(
@@ -168,7 +168,7 @@ class BatchNormalizationTest(TestCase):
 
         mean_tensor = bn.get_parameter_variables('mean')
         var_tensor = bn.get_parameter_variables('var')
-        updates = bn.get_update_operation()
+        updates = bn.get_update_operations()
 
         input_value = np.random.randn(*shape) - 100
         true_mean = input_value.mean(axis=0)

--- a/tests/unit/nn/model_test.py
+++ b/tests/unit/nn/model_test.py
@@ -86,10 +86,17 @@ class TestContainer(fixture.TestCase):
         )
 
         self.assertEqual(
-            container.get_parameter_variables(),
+            container.get_parameters_to_train(),
             (
-                models[0].get_parameter_variables() +
-                models[1].get_parameter_variables()
+                models[0].get_parameters_to_train() +
+                models[1].get_parameters_to_train()
+            )
+        )
+        self.assertEqual(
+            container.get_parameters_to_serialize(),
+            (
+                models[0].get_parameters_to_serialize() +
+                models[1].get_parameters_to_serialize()
             )
         )
         self.assertEqual(
@@ -115,8 +122,12 @@ class TestContainer(fixture.TestCase):
         )
         model = models[0].models['seq_1']
         self.assertEqual(
-            container.get_parameter_variables(),
-            model.get_parameter_variables(),
+            container.get_parameters_to_train(),
+            model.get_parameters_to_train(),
+        )
+        self.assertEqual(
+            container.get_parameters_to_serialize(),
+            model.get_parameters_to_serialize(),
         )
         self.assertEqual(
             container.get_output_tensors(),

--- a/tests/unit/nn/util/model_maker_test.py
+++ b/tests/unit/nn/util/model_maker_test.py
@@ -41,8 +41,8 @@ class ModelMakerTest(fixture.TestCase):
         out2 = layer2(tensor)
 
         for key in ['weight', 'bias']:
-            var1 = layer1.get_parameter_variables(key)
-            var2 = layer2.get_parameter_variables(key)
+            var1 = layer1.get_parameter_variable(key)
+            var2 = layer2.get_parameter_variable(key)
             self.assertIs(var1, var2)
 
         session = nn.Session()
@@ -88,8 +88,8 @@ class ModelMakerTest(fixture.TestCase):
             out2 = layer2(tensor)
 
         for key in ['weight', 'bias']:
-            var1 = layer1.get_parameter_variables(key)
-            var2 = layer2.get_parameter_variables(key)
+            var1 = layer1.get_parameter_variable(key)
+            var2 = layer2.get_parameter_variable(key)
             self.assertIs(var1, var2)
 
         session = nn.Session()


### PR DESCRIPTION
- Change `get_parameter_variables` to `get_parameter_variable`

Introducing `get_parameters_to_train` and `get_parameters_to_serialize` make the point of having `get_parameter_variables` less clear and in fact, returning all internal parameter can unnecessarily expose internal parameters. (like the case of `Conv2DTranspoe`.).

- Fix get_parameters_to_train

- Change from get_update_operation to get_update_operations

This gives more consistent interface between Layers and Models.