### PR TITLE
Add default session

### DIFF
--- a/luchador/agent/dqn.py
+++ b/luchador/agent/dqn.py
@@ -179,8 +179,9 @@ class DQNAgent(luchador.util.StoreMixin, BaseAgent):  # pylint: disable=R0902
         config = self.args['summary_writer_config']
         self._summary_writer = nn.SummaryWriter(**config)
 
-        if self._ql.session.graph:
-            self._summary_writer.add_graph(self._ql.session.graph)
+        sess = nn.get_session()
+        if sess.graph:
+            self._summary_writer.add_graph(sess.graph)
 
         model_0 = self._ql.models['model_0']
         params = model_0.get_parameters_to_serialize()

--- a/luchador/agent/rl/q_learning.py
+++ b/luchador/agent/rl/q_learning.py
@@ -213,7 +213,7 @@ class DeepQLearning(luchador.util.StoreMixin, object):
         self.optimizer = nn.fetch_optimizer(cfg['typename'])(**cfg['args'])
 
     def _init_session(self, initial_parameter=None):
-        self.session = nn.Session()
+        self.session = nn.get_session()
         if initial_parameter:
             _LG.info('Loading parameters from %s', initial_parameter)
             self.session.load_from_file(initial_parameter)

--- a/luchador/nn/core/__init__.py
+++ b/luchador/nn/core/__init__.py
@@ -12,7 +12,7 @@ from .impl.wrapper import (  # noqa
 from .impl.random import (  # noqa
     NormalRandom, UniformRandom,
 )
-from .impl.session import Session  # noqa
+from .impl.session import Session, get_session  # noqa
 from .impl import (  # noqa
     initializer,
     optimizer,

--- a/luchador/nn/core/impl/session.py
+++ b/luchador/nn/core/impl/session.py
@@ -4,6 +4,10 @@ from __future__ import absolute_import
 from ..base.session import BaseSession
 from ..backend import session
 
+__all__ = ['Session', 'get_session']
+
+_SESSIONS = {}
+
 
 class Session(session.Session, BaseSession):
     """Implement Tensorflow-like Session class which executes computation"""
@@ -74,3 +78,12 @@ class Session(session.Session, BaseSession):
             be skipped.
         """
         self._load_dataset(dataset=dataset, cast=cast, strict=strict)
+###############################################################################
+
+
+def get_session(key='default'):
+    """Get session"""
+    return _SESSIONS[key]
+
+
+_SESSIONS['default'] = Session()


### PR DESCRIPTION
So far, in Deep RL, we do not use multiple sessions, but there are occasions when we want to run computations in different parts of code.

So as to make `Session` accessible from anywhere, add default `Session`.

Since we do not use multiple `Session` objects, we are not adding registering method yet. YAGNI