### PR TITLE
Simplify model registration

### DIFF
--- a/luchador/nn/model/base_model.py
+++ b/luchador/nn/model/base_model.py
@@ -24,13 +24,9 @@ class BaseModel(object):  # pylint: disable=too-few-public-methods
         super(BaseModel, self).__init__()
         self.input = None
         self.output = None
-
-        if name:
-            scope = get_variable_scope().name
-            if scope:
-                name = '{}/{}'.format(scope, name)
-            _register(name, self)
         self.name = name
+        if name:
+            _register(name, self)
 
 
 def fetch_model(name):

--- a/tests/unit/nn/model_test.py
+++ b/tests/unit/nn/model_test.py
@@ -146,14 +146,14 @@ class ModelRetrievalTest(fixture.TestCase):
         scope1 = '{}/foo'.format(self.get_scope())
         scope2 = '{}/bar'.format(self.get_scope())
 
-        name = 'baz'
+        name1, name2 = 'baz1', 'baz2'
         with nn.variable_scope(scope1):
-            model1 = nn.model.Graph(name=name)
-            self.assertIs(nn.get_model(name), model1)
+            model1 = nn.model.Graph(name=name1)
+            self.assertIs(nn.get_model(name1), model1)
 
         with nn.variable_scope(scope2):
-            model2 = nn.model.Graph(name=name)
-            self.assertIs(nn.get_model(name), model2)
+            model2 = nn.model.Graph(name=name2)
+            self.assertIs(nn.get_model(name2), model2)
 
-        self.assertIs(nn.get_model('{}/{}'.format(scope1, name)), model1)
-        self.assertIs(nn.get_model('{}/{}'.format(scope2, name)), model2)
+        self.assertIs(nn.get_model(name1), model1)
+        self.assertIs(nn.get_model(name2), model2)


### PR DESCRIPTION
Instead of scoped name, use un-scoped name for model registration/retrieval.
Unlike Variable, Model is not copied so often.